### PR TITLE
Fix CHERI for superscalar config

### DIFF
--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -478,7 +478,7 @@ module cva6
   logic [CVA6Cfg.NrIssuePorts-1:0] lsu_valid_id_ex;
   logic lsu_ready_ex_id;
   // CLU
-  logic clu_valid_id_ex;
+  logic [CVA6Cfg.NrIssuePorts-1:0] clu_valid_id_ex;
 
   logic [CVA6Cfg.TRANS_ID_BITS-1:0] load_trans_id_ex_id;
   logic [CVA6Cfg.REGLEN-1:0] load_result_ex_id;

--- a/core/ex_stage.sv
+++ b/core/ex_stage.sv
@@ -146,7 +146,7 @@ module ex_stage
     // ALU2 instruction is valid - ISSUE_STAGE
     input logic [CVA6Cfg.NrIssuePorts-1:0] alu2_valid_i,
     // CLU instruction is ready
-    input logic clu_valid_i,
+    input logic [CVA6Cfg.NrIssuePorts-1:0] clu_valid_i,
     // CVXIF instruction is valid - ISSUE_STAGE
     input logic [CVA6Cfg.NrIssuePorts-1:0] x_valid_i,
     // CVXIF is ready - ISSUE_STAGE
@@ -402,7 +402,7 @@ module ex_stage
       flu_trans_id_o = mult_trans_id;
     end else if (|aes_valid_i) begin
       flu_result_o = aes_result;
-    end else if (clu_valid_i) begin
+    end else if (|clu_valid_i) begin
       flu_result_o = clu_result;
     end
   end
@@ -695,10 +695,6 @@ module ex_stage
   // CHERI Logic Unit
   // ----------------
   if (CVA6Cfg.CheriPresent) begin : gen_cheri_unit
-    fu_data_t clu_data;
-
-    assign clu_data = (clu_valid_i | branch_valid_i) ? fu_data_i : '0;
-
     cheri_unit #(
         .CVA6Cfg(CVA6Cfg),
         .exception_t(exception_t),
@@ -707,8 +703,8 @@ module ex_stage
         .clk_i,
         .rst_ni,
         .v_i,
-        .fu_data_i   (clu_data),
-        .clu_valid_i (clu_valid_i),
+        .fu_data_i   (one_cycle_data),
+        .clu_valid_i (|clu_valid_i),
         .alu_result_i(alu_result),
         .clu_result_o(clu_result)
     );

--- a/core/id_stage.sv
+++ b/core/id_stage.sv
@@ -159,15 +159,15 @@ module id_stage #(
   logic              [CVA6Cfg.NrIssuePorts-1:0][31:0] instruction_deco;
   logic              [CVA6Cfg.NrIssuePorts-1:0]       is_compressed_deco;
 
-  logic              [CVA6Cfg.NrIssuePorts-1:0]       int_mode_decode_o;
-  logic              [CVA6Cfg.NrIssuePorts-1:0]       int_mode_decode;
+  logic              [CVA6Cfg.NrIssuePorts-1:0]       int_mode_prev;
+  logic              [CVA6Cfg.NrIssuePorts-1:0]       int_mode_next;
   logic                                               int_mode_d;
   logic                                               int_mode_q;
   logic                                               commit_redirect_q;
 
-  assign int_mode_decode[0] = int_mode_q;
-  for (genvar i = 1; i <= CVA6Cfg.NrIssuePorts; i++) begin
-    assign int_mode_decode[i] = int_mode_decode_o[i-1];
+  assign int_mode_prev[0] = int_mode_q;
+  for (genvar i = 1; i < CVA6Cfg.NrIssuePorts; i++) begin
+    assign int_mode_prev[i] = int_mode_next[i-1];
   end
 
   if (CVA6Cfg.RVC) begin
@@ -179,7 +179,7 @@ module id_stage #(
           .CVA6Cfg(CVA6Cfg)
       ) compressed_decoder_i (
           .instr_i         (fetch_entry_i[i].instruction),
-          .int_mode_i      ((CVA6Cfg.CheriPresent) ? int_mode_decode[i] : 1'b0),
+          .int_mode_i      ((CVA6Cfg.CheriPresent) ? int_mode_prev[i] : 1'b0),
           .instr_o         (instruction_rvc[i]),
           .illegal_instr_o (is_illegal_rvc[i]),
           .is_compressed_o (is_compressed_rvc[i]),
@@ -335,7 +335,7 @@ module id_stage #(
         .irq_i,
         .pc_i                      (fetch_entry_i[i].address),
         .dii_id_i                  (fetch_entry_i[i].dii_id),
-        .int_mode_i                ((CVA6Cfg.CheriPresent) ? int_mode_decode[i] : 1'b0),
+        .int_mode_i                ((CVA6Cfg.CheriPresent) ? int_mode_prev[i] : 1'b0),
         .is_compressed_i           (is_compressed_deco[i]),
         .is_macro_instr_i          (is_macro_instr[i]),
         .is_zcmt_i                 (is_zcmt_instr[i]),
@@ -362,7 +362,7 @@ module id_stage #(
         .instruction_o             (decoded_instruction[i]),
         .orig_instr_o              (orig_instr[i]),
         .is_control_flow_instr_o   (is_control_flow_instr[i]),
-        .int_mode_o                (int_mode_decode_o[i])
+        .int_mode_o                (int_mode_next[i])
     );
   end
 
@@ -472,9 +472,9 @@ module id_stage #(
     if (commit_redirect_q) int_mode_d = int_mode_issue_i;
     else if (mispredict_redirect_i) int_mode_d = int_mode_resolved_branch_i;
     else begin
-      for (int i = 0; i <= CVA6Cfg.NrIssuePorts; i++) begin
-        if (fetch_entry_ready_o[i]) begin
-          int_mode_d = int_mode_decode_o[i];
+      for (int i = 0; i < CVA6Cfg.NrIssuePorts; i++) begin
+        if (fetch_entry_valid_i[i] && fetch_entry_ready_o[i]) begin
+          int_mode_d = int_mode_next[i];
         end
       end
     end

--- a/core/instr_realign.sv
+++ b/core/instr_realign.sv
@@ -204,7 +204,7 @@ module instr_realign
               end else begin
                 unaligned_instr_d   = instr_o[3];
                 unaligned_address_d = addr_o[3];
-                if (CVA6Cfg.RVFI_DII) unaligned_dii_id_d = dii_id_o[3];
+                if (CVA6Cfg.RVFI_DII) unaligned_dii_id_d = dii_id_o[2];
               end
             end
           end else begin
@@ -248,7 +248,7 @@ module instr_realign
                   unaligned_d         = 1'b1;
                   unaligned_instr_d   = instr_o[3];
                   unaligned_address_d = addr_o[3];
-                  if (CVA6Cfg.RVFI_DII) unaligned_dii_id_d = dii_id_o[3];
+                  if (CVA6Cfg.RVFI_DII) unaligned_dii_id_d = dii_id_o[2];
                 end
               end
             end else begin
@@ -270,7 +270,7 @@ module instr_realign
                   unaligned_d         = 1'b1;
                   unaligned_instr_d   = instr_o[3];
                   unaligned_address_d = addr_o[3];
-                  if (CVA6Cfg.RVFI_DII) unaligned_dii_id_d = dii_id_o[3];
+                  if (CVA6Cfg.RVFI_DII) unaligned_dii_id_d = dii_id_o[2];
                 end
               end
             end
@@ -321,7 +321,7 @@ module instr_realign
               unaligned_d         = 1'b1;
               unaligned_instr_d   = instr_o[2];
               unaligned_address_d = addr_o[2];
-              if (CVA6Cfg.RVFI_DII) unaligned_dii_id_d = dii_id_o[2];
+              if (CVA6Cfg.RVFI_DII) unaligned_dii_id_d = dii_id_o[1];
             end
           end
         end

--- a/core/issue_read_operands.sv
+++ b/core/issue_read_operands.sv
@@ -55,7 +55,7 @@ module issue_read_operands
     // Int mode flag in PCC register - ID_STAGE
     output logic int_mode_o,
     // PCC exception - Execute
-    output exception_t issue_pcc_ex_o,
+    output exception_t [CVA6Cfg.NrIssuePorts-1:0] issue_pcc_ex_o,
     // Backend Empty - scoreboard
     input logic backend_empty_i,
     // Forwarding - SCOREBOARD
@@ -461,7 +461,7 @@ module issue_read_operands
       pcc_base = cva6_cheri_pkg::get_cap_reg_base(pcc_q, pcc_meta);
       pcc_top = cva6_cheri_pkg::get_cap_reg_top(pcc_q, pcc_meta);
       pcc_bounds_root = cva6_cheri_pkg::are_cap_reg_bounds_root(pcc_q, pcc_meta);
-      issue_pcc_ex_o = 0;
+      issue_pcc_ex_o = '0;
       // Check PCC bounds every instruction
       for (int unsigned i = 0; i < CVA6Cfg.NrIssuePorts; i++) begin
         automatic logic [CVA6Cfg.VLEN-1:0] next_pc_off;
@@ -472,37 +472,37 @@ module issue_read_operands
         next_pc_off = ((issue_instr_i[i].is_compressed) ? {{CVA6Cfg.VLEN-2{1'b0}}, 2'h2} : {{CVA6Cfg.VLEN-3{1'b0}}, 3'h4});
         {next_pc_carry, next_pc_addr} = {1'b0, issue_instr_i[i].pc} + {1'b0, next_pc_off};
         if((cva6_cheri_pkg::addrw_t'(signed'(issue_instr_i[i].pc)) < pcc_base) || ({1'b0,cva6_cheri_pkg::addrw_t'(signed'(next_pc_addr))} > pcc_top) || (next_pc_carry && !pcc_bounds_root)) begin
-          issue_pcc_ex_o.cause = cva6_cheri_pkg::CAP_EXCEPTION;
+          issue_pcc_ex_o[i].cause = cva6_cheri_pkg::CAP_EXCEPTION;
           cheri_tval2.fault_cause = cva6_cheri_pkg::CAP_BOUNDS_VIOLATION;
-          issue_pcc_ex_o.tval2 = cheri_tval2;
-          issue_pcc_ex_o.valid = 1'b1;
+          issue_pcc_ex_o[i].tval2 = cheri_tval2;
+          issue_pcc_ex_o[i].valid = 1'b1;
         end
         if (issue_instr_i[i].needs_asr && !pcc[i].hperms.access_sys_regs) begin
-          issue_pcc_ex_o.cause = cva6_cheri_pkg::CAP_EXCEPTION;
+          issue_pcc_ex_o[i].cause = cva6_cheri_pkg::CAP_EXCEPTION;
           cheri_tval2.fault_cause = cva6_cheri_pkg::CAP_PERM_VIOLATION;
-          issue_pcc_ex_o.tval2 = cheri_tval2;
-          issue_pcc_ex_o.valid = 1'b1;
+          issue_pcc_ex_o[i].tval2 = cheri_tval2;
+          issue_pcc_ex_o[i].valid = 1'b1;
         end
         if (!pcc[i].hperms.permit_execute) begin
-          issue_pcc_ex_o.cause    = cva6_cheri_pkg::CAP_EXCEPTION;
+          issue_pcc_ex_o[i].cause = cva6_cheri_pkg::CAP_EXCEPTION;
           cheri_tval2.fault_cause = cva6_cheri_pkg::CAP_PERM_VIOLATION;
-          issue_pcc_ex_o.tval2    = cheri_tval2;
-          issue_pcc_ex_o.valid    = 1'b1;
+          issue_pcc_ex_o[i].tval2 = cheri_tval2;
+          issue_pcc_ex_o[i].valid = 1'b1;
         end
         if ((pcc[i].otype != cva6_cheri_pkg::UNSEALED_CAP) && pcc[i].tag) begin
-          issue_pcc_ex_o.cause    = cva6_cheri_pkg::CAP_EXCEPTION;
+          issue_pcc_ex_o[i].cause = cva6_cheri_pkg::CAP_EXCEPTION;
           cheri_tval2.fault_cause = cva6_cheri_pkg::CAP_SEAL_VIOLATION;
-          issue_pcc_ex_o.tval2    = cheri_tval2;
-          issue_pcc_ex_o.valid    = 1'b1;
+          issue_pcc_ex_o[i].tval2 = cheri_tval2;
+          issue_pcc_ex_o[i].valid = 1'b1;
         end
         if (!pcc[i].tag) begin
-          issue_pcc_ex_o.cause = cva6_cheri_pkg::CAP_EXCEPTION;
+          issue_pcc_ex_o[i].cause = cva6_cheri_pkg::CAP_EXCEPTION;
           cheri_tval2.fault_cause = cva6_cheri_pkg::CAP_TAG_VIOLATION;
-          issue_pcc_ex_o.tval2 = cheri_tval2;
-          issue_pcc_ex_o.valid = 1'b1;
+          issue_pcc_ex_o[i].tval2 = cheri_tval2;
+          issue_pcc_ex_o[i].valid = 1'b1;
         end
+        if (!issue_instr_valid_i[i] || debug_mode_i) issue_pcc_ex_o[i].valid = 1'b0;
       end
-      if (!issue_instr_valid_i || debug_mode_i) issue_pcc_ex_o.valid = 1'b0;
     end
   end
 

--- a/core/issue_read_operands.sv
+++ b/core/issue_read_operands.sv
@@ -109,7 +109,7 @@ module issue_read_operands
     // CVXIF FU is valid - EX_STAGE
     output logic [CVA6Cfg.NrIssuePorts-1:0] cvxif_valid_o,
     // CLU result is valid - EX_STAGE
-    output logic clu_valid_o,
+    output logic [CVA6Cfg.NrIssuePorts-1:0] clu_valid_o,
     // CVXIF is FU ready - EX_STAGE
     input logic cvxif_ready_i,
     // CVXIF offloader instruction value - EX_STAGE

--- a/core/issue_read_operands.sv
+++ b/core/issue_read_operands.sv
@@ -415,6 +415,7 @@ module issue_read_operands
           end else begin
             fus_busy[1].alu = 1'b1;
             fus_busy[1].ctrl_flow = 1'b1;
+            fus_busy[1].clu = 1'b1;
             fus_busy[1].csr = 1'b1;
           end
         end
@@ -432,7 +433,10 @@ module issue_read_operands
           fus_busy[1].store = 1'b1;
         end
         CLU: begin
+          fus_busy[1].alu = 1'b1;
           fus_busy[1].clu = 1'b1;
+          fus_busy[1].ctrl_flow = 1'b1;
+          fus_busy[1].csr = 1'b1;
         end
         CVXIF: ;
         default: ;

--- a/core/issue_stage.sv
+++ b/core/issue_stage.sv
@@ -106,7 +106,7 @@ module issue_stage
     // CSR is valid - EX_STAGE
     output logic [CVA6Cfg.NrIssuePorts-1:0] csr_valid_o,
     // CLU is valid - EX_STAGE
-    output logic clu_valid_o,
+    output logic [CVA6Cfg.NrIssuePorts-1:0] clu_valid_o,
     // CVXIF FU is valid - EX_STAGE
     output logic [CVA6Cfg.NrIssuePorts-1:0] xfu_valid_o,
     // CVXIF is FU ready - EX_STAGE

--- a/core/issue_stage.sv
+++ b/core/issue_stage.sv
@@ -211,7 +211,7 @@ module issue_stage
 
   logic                                               backend_empty;
 
-  exception_t                                         issue_pcc_ex;
+  exception_t        [CVA6Cfg.NrIssuePorts-1:0]       issue_pcc_ex;
 
   assign issue_instr_hs_o = issue_instr_valid_sb_iro[0] & issue_ack_iro_sb[0];
   assign issue_instr_o = issue_instr_sb_iro;

--- a/corev_apu/tb/tb_testRig_cheri/hdl/rvfi_dii_generator.sv
+++ b/corev_apu/tb/tb_testRig_cheri/hdl/rvfi_dii_generator.sv
@@ -48,16 +48,18 @@ module rvfi_dii_generator
     logic [CVA6Cfg.VLEN-1:0] vaddr_buff;
 
     logic found_last_id_q, found_last_id_d;
-    logic [CVA6Cfg.DIIIDLEN-1:0] test_last_id_q;
+    logic [CVA6Cfg.DIIIDLEN-1:0] test_last_id_q, test_last_id_d;
 
     always_comb begin
         automatic logic [CVA6Cfg.FETCH_WIDTH*2-1:0] instr = '0; // Wider than needed to be shifted in
         automatic logic [2:0] instr_bytes = '0;
         automatic logic [CVA6Cfg.DIIIDLEN-1:0] last_id_offset = '0;
+        automatic logic past_end = '0;
         dii_id_d = dii_id_q;
         fetch_offset_d = fetch_offset_q;
         fetch_buff_d = fetch_buff_q;
-        found_last_id_d = 1'b0;
+        found_last_id_d = found_last_id_q;
+        test_last_id_d = test_last_id_q;
         if (busy && !dreq_i.kill_s2) begin
             // Assume the pipeline consumed the full buffer
             fetch_offset_d = {1'b0, fetch_offset_d[CVA6Cfg.FETCH_ALIGN_BITS-1:0]};
@@ -66,13 +68,19 @@ module rvfi_dii_generator
             fetch_offset_d = fetch_offset_d + vaddr_buff[CVA6Cfg.FETCH_ALIGN_BITS-1:0];
             fetch_buff_d = fetch_buff_d << {vaddr_buff[CVA6Cfg.FETCH_ALIGN_BITS-1:0], 3'b0};
             while (~fetch_offset_d[CVA6Cfg.FETCH_ALIGN_BITS] & (~fetch_offset_d[CVA6Cfg.FETCH_ALIGN_BITS-1:0] != 0)) begin
-                last_id_offset = dii_id_d - test_last_id_q;
-                found_last_id_d = (found_last_id_q && ~last_id_offset[CVA6Cfg.DIIIDLEN-1]) || get_dii_cmd(dii_id_d) == 0;
-                instr = found_last_id_d ? end_of_test_instr : get_dii_insn(dii_id_d);
+                last_id_offset = dii_id_d - test_last_id_d;
+                past_end = found_last_id_d && ~last_id_offset[CVA6Cfg.DIIIDLEN-1];
+                if (!found_last_id_d && get_dii_cmd(dii_id_d) == 0) begin
+                    found_last_id_d = 1'b1;
+                    test_last_id_d = dii_id_d;
+                end
+                // It seems the call to get_dii_insn can happen even if we're past the end
+                // Make sure the argument is always legal so we don't hang if it gets called spuriously
+                instr = past_end ? end_of_test_instr : get_dii_insn(past_end ? test_last_id_d : dii_id_d);
                 instr_bytes = instr[1:0] == 2'b11 ? 3'd4 : 3'd2;
                 fetch_buff_d = fetch_buff_d | (instr << ({fetch_offset_d, 3'b0}));
                 fetch_offset_d = fetch_offset_d + instr_bytes;
-                if (!found_last_id_d) dii_id_d = dii_id_d + 1;
+                if (!past_end) dii_id_d = dii_id_d + 1;
             end
             dreq_o.valid = 1'b1;
         end else begin
@@ -96,8 +104,8 @@ module rvfi_dii_generator
             found_last_id_q <= '0;
             test_last_id_q <= '0;
         end else begin
-            found_last_id_q <= found_last_id_q | found_last_id_d;
-            if (found_last_id_d) test_last_id_q <= dii_id_d;
+            found_last_id_q <= found_last_id_d;
+            test_last_id_q <= test_last_id_d;
             if (dreq_i.kill_s1 || dreq_i.kill_s2) begin
                 fetch_buff_q <= '0;
                 fetch_offset_q <= '0;


### PR DESCRIPTION
Add fixes required to enable superscalar CHERI, without actually enabling it in any of the default configs.

Tested with TestRIG, and boots CheriBSD up to the point where lack of floating point support becomes an issue in userspace.