### PR TITLE
Improve timing for PCC change check

### DIFF
--- a/core/branch_unit.sv
+++ b/core/branch_unit.sv
@@ -106,6 +106,7 @@ module branch_unit #(
     resolved_branch_o.is_taken = 1'b0;
     resolved_branch_o.valid = branch_valid_i;
     resolved_branch_o.is_mispredict = 1'b0;
+    resolved_branch_o.is_pcc_change = 1'b0;
     resolved_branch_o.cf_type = branch_predict_i.cf;
     // calculate target address simple 64 bit addition
     target_address = $unsigned($signed(jump_base) + $signed(fu_data_i.imm[CVA6Cfg.VLEN-1:0]));
@@ -124,8 +125,21 @@ module branch_unit #(
         branch_result_o = cva6_cheri_pkg::set_cap_reg_otype(
             cva6_cheri_pkg::cap_pcc_to_cap_reg(next_pc), cva6_cheri_pkg::SENTRY_CAP);
         if (fu_data_i.operation inside {ariane_pkg::CJALR}) begin
+          automatic cva6_cheri_pkg::cap_pcc_t compare_pcc;
+          automatic cva6_cheri_pkg::cap_pcc_t compare_target_cap;
+          compare_pcc = cva6_cheri_pkg::set_cap_reg_flags(pcc, 0);
+          compare_target_cap = cva6_cheri_pkg::set_cap_reg_flags(
+              cva6_cheri_pkg::set_cap_reg_otype(operand_a, cva6_cheri_pkg::UNSEALED_CAP), 0);
           target_address =
               cva6_cheri_pkg::set_cap_reg_otype(target_address, cva6_cheri_pkg::UNSEALED_CAP);
+          if (compare_target_cap != cva6_cheri_pkg::set_cap_reg_address(
+                  compare_pcc,
+                  compare_target_cap[CVA6Cfg.XLEN-1:0],
+                  cva6_cheri_pkg::get_cap_reg_meta_data(
+                      pcc)
+              )) begin
+            resolved_branch_o.is_pcc_change = 1'b1;
+          end
           // If jumping into intmode, we must have been in capmode, so always mispredict
           if (cva6_cheri_pkg::get_cap_reg_flags(target_address) == 1'b1)
             resolved_branch_o.is_mispredict = branch_valid_i;

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -142,13 +142,14 @@ module cva6
     // all the necessary data structures
     // bp_resolve_t
     localparam type bp_resolve_t = struct packed {
-      logic                        valid;           // prediction with all its values is valid
-      logic [CVA6Cfg.VLEN-1:0]     pc;              // PC of predict or mis-predict
-      logic [CVA6Cfg.DIIIDLEN-1:0] dii_id;          // dii id of branch
-      logic [CVA6Cfg.PCLEN-1:0]    target_address;  // target address at which to jump, or not
-      logic                        is_mispredict;   // set if this was a mis-predict
-      logic                        is_taken;        // branch is taken
-      cf_t                         cf_type;         // Type of control flow change
+      logic valid;  // prediction with all its values is valid
+      logic [CVA6Cfg.VLEN-1:0] pc;  // PC of predict or mis-predict
+      logic [CVA6Cfg.DIIIDLEN-1:0] dii_id;  // dii id of branch
+      logic [CVA6Cfg.PCLEN-1:0] target_address;  // target address at which to jump, or not
+      logic is_mispredict;  // set if this was a mis-predict
+      logic is_taken;  // branch is taken
+      logic is_pcc_change;  // with CHERI: set if the branch changes PCC metadata
+      cf_t cf_type;  // Type of control flow change
     },
 
     // All information needed to determine whether we need to associate an interrupt

--- a/core/issue_read_operands.sv
+++ b/core/issue_read_operands.sv
@@ -837,15 +837,7 @@ module issue_read_operands
         else pcc_n = pcc_q;
 
         if (eret_i || set_pc_commit_i || ex_valid_i) pcc_jump_change_valid_n = 1'b0;
-        else if (resolved_branch_i.valid && (cva6_cheri_pkg::set_cap_reg_flags(
-                resolved_branch_i.target_address, 0
-            ) != cva6_cheri_pkg::set_cap_reg_address(
-                cva6_cheri_pkg::set_cap_reg_flags(
-                    pcc_q, 0
-                ),
-                resolved_branch_i.target_address[CVA6Cfg.XLEN-1:0],
-                pcc_meta
-            ))) begin
+        else if (resolved_branch_i.valid && resolved_branch_i.is_pcc_change) begin
           pcc_jump_change_valid_n = 1'b1;
         end else if (backend_empty_i) pcc_jump_change_valid_n = 1'b0;
         else pcc_jump_change_valid_n = pcc_jump_change_valid_q;


### PR DESCRIPTION
The old implementation checked the fully calculated target capability to see if the metadata differed from PCC. We can instead use the base register, since this must have the same metadata as the eventual target. We move the computation of whether we are changing the PCC metadata into the branch unit, which has the information of the base capability earlier.

I have checked this significantly improved the critical path and done some quick TestRIG testing, but still need to check it in hardware.