### PR TITLE
Bootrom: Wait for TX empty before starting transmit

### DIFF
--- a/corev_apu/fpga/src/bootrom/src/spi.c
+++ b/corev_apu/fpga/src/bootrom/src/spi.c
@@ -105,6 +105,8 @@ int spi_write_bytes(uint8_t *bytes, uint32_t len, uint8_t *ret)
     // enable slave select
     write_reg(SPI_SLAVE_SELECT_REG, 0xfffffffe);
 
+    wait_for_tx_empty();
+
     for (int i = 0; i < len; i++)
     {
         write_reg(SPI_TRANSMIT_REG, bytes[i] & 0xff);


### PR DESCRIPTION
For faster bitstreams (with hpdcache or superscalar) it seems we could build up a TX backlog that would lead to overfilling the FIFO without this check