### PR TITLE
Add checks to detect a setbounds result with malformed bounds

### DIFF
--- a/core/include/cva6_cheri_pkg.sv
+++ b/core/include/cva6_cheri_pkg.sv
@@ -660,10 +660,7 @@ package cva6_cheri_pkg;
 
     // perform well-formed checks on the result cap
     ////////////////////////////////////////////////////////////////////////
-    if (final_exp == 6'd0 && final_base_bits != '0) begin
-      ret.cap.tag = 1'b0;
-    end
-    if (final_exp == 6'd1 && final_base_bits[CAP_M_WIDTH-1] != 1'b0) begin
+    if (final_exp == 6'd0 && base[CAP_ADDR_WIDTH-1-:CAP_M_WIDTH-2] != '0) begin
       ret.cap.tag = 1'b0;
     end
 

--- a/core/include/cva6_cheri_pkg.sv
+++ b/core/include/cva6_cheri_pkg.sv
@@ -658,6 +658,15 @@ package cva6_cheri_pkg;
                                                   : ~lmask_lo )
                     : {CAP_ADDR_WIDTH + 2{1'b1}};
 
+    // perform well-formed checks on the result cap
+    ////////////////////////////////////////////////////////////////////////
+    if (final_exp == 6'd0 && final_base_bits != '0) begin
+      ret.cap.tag = 1'b0;
+    end
+    if (final_exp == 6'd1 && final_base_bits[CAP_M_WIDTH-1] != 1'b0) begin
+      ret.cap.tag = 1'b0;
+    end
+
     // fold in return values and return
     ////////////////////////////////////////////////////////////////////////
     ret.cap.EF = fmt;


### PR DESCRIPTION
This was highlighted by a data-type-invariant found by the Oxford team. The new spec has an unfortunate possibility that a setBounds (e.g. base UINT_MAX, length UINT_MAX) can produce a cap with bad bounds. We need to check for this in the setBounds logic and clear the tag. This may be bad for timing and area: remains to be seen if this can be optimised in some way