### PR TITLE
Apply GCMODE legalisation fix from mndstrmr

### DIFF
--- a/core/include/cva6_cheri_pkg.sv
+++ b/core/include/cva6_cheri_pkg.sv
@@ -449,7 +449,7 @@ package cva6_cheri_pkg;
 
   function automatic cap_flags_t get_cap_reg_flags(cap_reg_t cap);
     cap_hperms_t perms = legalize_arch_perms(cap.hperms);
-    return (perms.permit_execute) ? cap.flags : 1'b0;
+    return (perms == cap.hperms && perms.permit_execute) ? cap.flags : 1'b0;
   endfunction
 
   function automatic cap_reg_t set_cap_reg_flags(cap_reg_t cap, cap_flags_t flags);


### PR DESCRIPTION
Looking through the call sites, this looks correct in all cases. In some cases, where we're using this as a PCC already, we shouldn't need these checks at all as we would already be trapping if they fail. This is potential for future optimisation.

From the original commit:
See the issue tracker for details:
Capabilities-Limited/cheri-cva6#26

In brief, the Sail specification expects GCMODE to return 0 if the input capability has invalid permissions. The RTL does not do this, until this fix.