### PR TITLE
Fix ACPERM legalisation bug

### DIFF
--- a/core/cheri_unit.sv
+++ b/core/cheri_unit.sv
@@ -100,11 +100,14 @@ module cheri_unit
       end
       // CAndPerm
       ariane_pkg::ACPERM: begin
-        automatic cap_report_perms_t mask = cap_report_perms_t'(operand_b_address);
+        automatic cap_report_perms_t new_perms;
         check_operand_a_violations.seal = 1'b1;
         tmp_cap = operand_a;
-        tmp_cap.uperms = (tmp_cap.uperms & mask.uperms);
-        tmp_cap.hperms = cap_hperms_t'(tmp_cap.hperms & report_perms_to_hperms(mask));
+        new_perms = hperms_and_uperms_to_report_perms(operand_a.hperms, operand_a.uperms,
+                                                      operand_a_hperms_malformed);
+        new_perms &= cap_report_perms_t'(operand_b_address);
+        tmp_cap.uperms = new_perms.uperms;
+        tmp_cap.hperms = legalize_arch_perms(report_perms_to_hperms(new_perms));
         if (!tmp_cap.hperms.permit_execute) tmp_cap.flags.int_mode = 1'b0;
         clu_result = tmp_cap;
       end
@@ -173,7 +176,7 @@ module cheri_unit
           {
             {CVA6Cfg.XLEN - $bits(cap_report_perms_t) {1'b0}},
             hperms_and_uperms_to_report_perms(
-              operand_a.hperms, operand_a.uperms, operand_a.flags.int_mode
+              operand_a.hperms, operand_a.uperms, operand_a_hperms_malformed
             )
           }
         );

--- a/core/include/cva6_cheri_pkg.sv
+++ b/core/include/cva6_cheri_pkg.sv
@@ -742,10 +742,8 @@ package cva6_cheri_pkg;
       * @returns permissions in the report format for gcperms.
       */
   function automatic cap_report_perms_t hperms_and_uperms_to_report_perms(
-      cap_hperms_t hp_raw, upermsw_t up, bool_t int_mode);
-    cap_hperms_t hp = ((legalize_arch_perms(
-        hp_raw
-    ) != hp_raw) || (int_mode && !hp_raw.permit_execute)) ? '0 : hp_raw;
+      cap_hperms_t hp_raw, upermsw_t up, logic perms_are_malformed);
+    cap_hperms_t hp = perms_are_malformed ? '0 : hp_raw;
     cap_report_perms_t rp = '{
         reserved_hi          : 0,  //Newer spec:'1,
         permit_load          : hp.permit_load,
@@ -754,8 +752,7 @@ package cva6_cheri_pkg;
         reserved_lo          : 0,  //Newer spec:'1,
         uperms               : up,
         permit_cap           : hp.permit_cap,
-        cap_level            :
-            hp_raw.cap_level,  // Not a permission, so not subject to the same legalisation
+        cap_level            : hp_raw.cap_level,  // Not a permission, so not legalised
         permit_store_level   : hp.permit_store_level,
         permit_elevate_level : hp.permit_elevate_level,
         permit_load_mutable  : hp.permit_load_mutable,
@@ -767,7 +764,7 @@ package cva6_cheri_pkg;
   /**
       * @brief Function to convert from reported permissions format for andperms to encoded hardware permissions.
       * @param permissions in the report format for ACPERM.
-      * @returns hardware permissions in encoded format.
+      * @returns hardware permissions in encoded format. Note that legalisation must be performed outside.
       */
   function automatic cap_hperms_t report_perms_to_hperms(cap_report_perms_t rp);
     cap_hperms_t hp = '{
@@ -781,7 +778,7 @@ package cva6_cheri_pkg;
         permit_cap           : rp.permit_cap,
         cap_level            : rp.cap_level
     };
-    return legalize_arch_perms(hp);
+    return hp;
   endfunction
 
   /**


### PR DESCRIPTION
As reported by Louis-Emile (mndstrmr) from Oxford formal verification, the previous implementation failed to zero the perms when they were invalid, and did not legalise the result perms.

Move to performing the andperms on the "report perms" rather than the "hperms". As the bits are just rearranged for RV64, this is unlikely to incur any extra hardware, and is more intentionally correct.

Also don't legalise inside the conversion from report perms to hperms. The mode needs to be legalised outside anyway, so this just added potential confusion.

Finally, the malformed_perm check was being performed redundantly both inside and outside the library for gcperms, so refactor this a little.