### PR TITLE
Fix DIIIDLEN as 6 for all configs

### DIFF
--- a/core/include/build_config_pkg.sv
+++ b/core/include/build_config_pkg.sv
@@ -173,7 +173,7 @@ package build_config_pkg;
 
     cfg.CheriCapTagWidth = CVA6Cfg.CheriCapTagWidth;
     cfg.RVFI_DII = bit'(CVA6Cfg.RVFI_DII);
-    cfg.DIIIDLEN = CVA6Cfg.DIIIDLEN;
+    cfg.DIIIDLEN = 6;
 
     cfg.DATA_USER_EN = CVA6Cfg.DataUserEn;
     cfg.WtDcacheWbufDepth = CVA6Cfg.WtDcacheWbufDepth;

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -250,8 +250,6 @@ package config_pkg;
     int unsigned                 CheriCapTagWidth;
     // Enable RVDI_DII interface
     int unsigned                 RVFI_DII;
-    // DII ID Length
-    int unsigned                 DIIIDLEN;
   } cva6_user_cfg_t;
 
   typedef struct packed {

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -115,8 +115,7 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(1),
       CheriCapTagWidth : int'(1),
-      RVFI_DII : int'(0),
-      DIIIDLEN : int'(0)
+      RVFI_DII : int'(0)
   };
 
 endpackage

--- a/core/include/cv32a65x_config_pkg.sv
+++ b/core/include/cv32a65x_config_pkg.sv
@@ -118,8 +118,7 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(1),
       CheriCapTagWidth : int'(1),
-      RVFI_DII : int'(0),
-      DIIIDLEN : int'(0)
+      RVFI_DII : int'(0)
   };
 
 endpackage

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -170,8 +170,7 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       CheriCapTagWidth : int'(1),
-      RVFI_DII : int'(0),
-      DIIIDLEN : int'(0)
+      RVFI_DII : int'(0)
   };
 
 endpackage

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -169,8 +169,7 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       CheriCapTagWidth : int'(1),
-      RVFI_DII : int'(0),
-      DIIIDLEN : int'(0)
+      RVFI_DII : int'(0)
   };
 
 endpackage

--- a/core/include/cv64a60ax_config_pkg.sv
+++ b/core/include/cv64a60ax_config_pkg.sv
@@ -151,8 +151,7 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(0),
       DcacheIdWidth: int'(3),
       CheriCapTagWidth : int'(1),
-      RVFI_DII: int'(0),
-      DIIIDLEN: int'(0)
+      RVFI_DII: int'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -33,7 +33,6 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigCheriCapTagWidth = 1;
   localparam CVA6ConfigRVFI_DII = 0;
-  localparam CVA6ConfigDIIIDLEN = 0;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -177,8 +176,7 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       CheriCapTagWidth : int'(CVA6ConfigCheriCapTagWidth),
-      RVFI_DII : int'(CVA6ConfigRVFI_DII),
-      DIIIDLEN : int'(CVA6ConfigDIIIDLEN)
+      RVFI_DII : int'(CVA6ConfigRVFI_DII)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
@@ -180,8 +180,7 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       CheriCapTagWidth : int'(1),
-      RVFI_DII : int'(0),
-      DIIIDLEN : int'(0)
+      RVFI_DII : int'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_wb_config_pkg.sv
@@ -180,8 +180,7 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       CheriCapTagWidth: int'(1),
-      RVFI_DII: int'(0),
-      DIIIDLEN: int'(0)
+      RVFI_DII: int'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -173,8 +173,7 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       CheriCapTagWidth : int'(1),
-      RVFI_DII : int'(0),
-      DIIIDLEN : int'(0)
+      RVFI_DII : int'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
@@ -173,8 +173,7 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       CheriCapTagWidth : int'(1),
-      RVFI_DII : int'(0),
-      DIIIDLEN : int'(0)
+      RVFI_DII : int'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdch_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdch_sv39_config_pkg.sv
@@ -173,8 +173,7 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       CheriCapTagWidth : int'(1),
-      RVFI_DII : int'(0),
-      DIIIDLEN : int'(0)
+      RVFI_DII : int'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdch_sv39_rvfi_dii_config_pkg.sv
+++ b/core/include/cv64a6_imafdch_sv39_rvfi_dii_config_pkg.sv
@@ -30,7 +30,6 @@ package cva6_config_pkg;
   localparam CVA6ConfigRVZcherihybrid = 0;
   localparam CVA6ConfigCheriCapTagWidth = 1;
   localparam CVA6ConfigRVFI_DII = 1;
-  localparam CVA6ConfigDIIIDLEN = 6;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -168,8 +167,7 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       CheriCapTagWidth : int'(CVA6ConfigCheriCapTagWidth),
-      RVFI_DII : int'(CVA6ConfigRVFI_DII),
-      DIIIDLEN : int'(CVA6ConfigDIIIDLEN)
+      RVFI_DII : int'(CVA6ConfigRVFI_DII)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdch_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdch_sv39_wb_config_pkg.sv
@@ -173,8 +173,7 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       CheriCapTagWidth : int'(1),
-      RVFI_DII : int'(0),
-      DIIIDLEN : int'(0)
+      RVFI_DII : int'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdchzcheri_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdchzcheri_sv39_config_pkg.sv
@@ -32,7 +32,6 @@ package cva6_config_pkg;
   localparam CVA6ConfigRVZcherihybrid = 1;
   localparam CVA6ConfigCheriCapTagWidth = 1;
   localparam CVA6ConfigRVFI_DII = 0;
-  localparam CVA6ConfigDIIIDLEN = 0;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -176,8 +175,7 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       CheriCapTagWidth : int'(CVA6ConfigCheriCapTagWidth),
-      RVFI_DII : int'(CVA6ConfigRVFI_DII),
-      DIIIDLEN : int'(CVA6ConfigDIIIDLEN)
+      RVFI_DII : int'(CVA6ConfigRVFI_DII)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdchzcheri_sv39_rvfi_dii_config_pkg.sv
+++ b/core/include/cv64a6_imafdchzcheri_sv39_rvfi_dii_config_pkg.sv
@@ -30,7 +30,6 @@ package cva6_config_pkg;
   localparam CVA6ConfigRVZcherihybrid = 1;
   localparam CVA6ConfigCheriCapTagWidth = 1;
   localparam CVA6ConfigRVFI_DII = 1;
-  localparam CVA6ConfigDIIIDLEN = 6;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -174,8 +173,7 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       CheriCapTagWidth : int'(CVA6ConfigCheriCapTagWidth),
-      RVFI_DII : int'(CVA6ConfigRVFI_DII),
-      DIIIDLEN : int'(CVA6ConfigDIIIDLEN)
+      RVFI_DII : int'(CVA6ConfigRVFI_DII)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
@@ -175,7 +175,6 @@ package cva6_config_pkg;
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth),
       CheriCapTagWidth : int'(1),
-      RVFI_DII : int'(0),
-      DIIIDLEN : int'(0)
+      RVFI_DII : int'(0)
   };
 endpackage


### PR DESCRIPTION
A DIIIDLEN of 0 causes signals to be declared as logic[INTMAX:0] in non-DII cases, which is sensibly rejected by some tools.

We ensure we never read or write the signals with RVFI_DII disabled, so this should not incur any extra logic.