### PR TITLE
Converge different toplevels' treatment of the tag controller

### DIFF
--- a/corev_apu/fpga/src/ariane_xilinx.sv
+++ b/corev_apu/fpga/src/ariane_xilinx.sv
@@ -246,6 +246,7 @@ localparam AxiDataWidth = 64;
 localparam AxiIdWidthMaster = 4;
 localparam AxiIdWidthSlaves = AxiIdWidthMaster + $clog2(NBSlave); // 5
 localparam AxiUserWidth = CVA6Cfg.AxiUserWidth;
+localparam AxiCheriExtraIdBits = CVA6Cfg.CheriPresent ? 1 : 0;
 
 `AXI_TYPEDEF_ALL(axi_slave,
                  logic [    AxiAddrWidth-1:0],
@@ -802,7 +803,7 @@ ariane #(
 ) i_ariane (
     .clk_i        ( clk                 ),
     .rst_ni       ( ndmreset_n          ),
-    .boot_addr_i  ( (CVA6Cfg.CheriPresent) ? boot_cap : ariane_soc::ROMBase ), // start fetching from ROM
+    .boot_addr_i  ( CVA6Cfg.CheriPresent ? boot_cap : ariane_soc::ROMBase ), // start fetching from ROM
     .hart_id_i    ( '0                  ),
     .irq_i        ( irq                 ),
     .ipi_i        ( ipi                 ),
@@ -1205,10 +1206,10 @@ AXI_BUS #(
 ) dram();
 
 AXI_BUS #(
-  .AXI_ADDR_WIDTH ( AxiAddrWidth            ),
-  .AXI_DATA_WIDTH ( AxiDataWidth               ),
-  .AXI_ID_WIDTH   ( AxiIdWidthSlaves + 1 ),
-  .AXI_USER_WIDTH ( AxiUserWidth               )
+  .AXI_ADDR_WIDTH ( AxiAddrWidth                           ),
+  .AXI_DATA_WIDTH ( AxiDataWidth                           ),
+  .AXI_ID_WIDTH   ( AxiIdWidthSlaves + AxiCheriExtraIdBits ),
+  .AXI_USER_WIDTH ( AxiUserWidth                           )
 ) tag_mst();
 
 axi_riscv_atomics_wrap #(
@@ -1234,10 +1235,10 @@ axi_riscv_atomics_wrap #(
   } rule_full_t;
 
 localparam int unsigned AxiStrbWidth = AxiDataWidth / 32'd8;
-  typedef logic [AxiIdWidth:0] axi_mst_id_t;
+  typedef logic [(AxiIdWidthSlaves+AxiCheriExtraIdBits)-1:0] axi_mst_id_t;
   typedef logic [AxiDataWidth-1:0] axi_data_t;
   typedef logic [AxiStrbWidth-1:0] axi_strb_t;
-  typedef logic  axi_user_t;
+  typedef logic axi_user_t;
   typedef logic [7:0] byte_t;
 
   `AXI_TYPEDEF_AW_CHAN_T(axi_mst_aw_t, axi_addr_t, axi_mst_id_t, axi_user_t)
@@ -1253,45 +1254,49 @@ localparam int unsigned AxiStrbWidth = AxiDataWidth / 32'd8;
   ariane_axi_soc::resp_slv_t dram_resp;
   axi_mst_req_t axi_tag_req;
   axi_mst_resp_t axi_tag_resp;
-  `AXI_ASSIGN_TO_REQ(dram_req,   dram)
-  `AXI_ASSIGN_FROM_RESP( dram, dram_resp)
+  `AXI_ASSIGN_TO_REQ(dram_req, dram)
+  `AXI_ASSIGN_FROM_RESP(dram, dram_resp)
   `AXI_ASSIGN_FROM_REQ(tag_mst, axi_tag_req)
-  `AXI_ASSIGN_TO_RESP(  axi_tag_resp, tag_mst)
+  `AXI_ASSIGN_TO_RESP(axi_tag_resp, tag_mst)
   `REG_BUS_TYPEDEF_ALL(conf, logic [31:0], logic [31:0], logic [3:0])
 
-  axi_tagctrl_reg_wrap #(
-      .DRAMMemBase    (DRAMMemBase),
-     .CapSize         (CapSize),
-      .TagCacheMemBase (TagCacheMemBase),
-      .SetAssociativity(SetAssociativity),
-      .NumLines        (NumLines),
-      .NumBlocks       (NumBlocks),
-      .AxiIdWidth      (ariane_axi_soc::IdWidthSlave),
-      .AxiAddrWidth    (AxiAddrWidth),
-      .AxiDataWidth    (AxiDataWidth),
-      .AxiUserWidth    (AxiUserWidth),
-      .slv_req_t       (ariane_axi_soc::req_slv_t),
-      .slv_resp_t      (ariane_axi_soc::resp_slv_t),
-      .mst_req_t       (axi_mst_req_t),
-      .mst_resp_t      (axi_mst_resp_t),
-      .reg_req_t       (conf_req_t),
-      .reg_resp_t      (conf_rsp_t),
-      .rule_full_t     (rule_full_t),
-      .PrintSramCfg    (1'b0)
-  ) i_axi_tagctrl_reg_wrap_raw (
-      .clk_i(clk),
-      .rst_ni (ndmreset_n),
-      .test_i             (1'b0),
-      .slv_req_i          (dram_req),
-      .slv_resp_o         (dram_resp),
-      .mst_req_o          (axi_tag_req),
-      .mst_resp_i         (axi_tag_resp),
-      .conf_req_i         (  /* not used */),
-      .conf_resp_o        (  /* not used */),
-      .cached_start_addr_i(DRAMBase),
-      .cached_end_addr_i  (TagCacheMemBase)
-  );
-
+  if (CVA6Cfg.CheriPresent) begin
+    axi_tagctrl_reg_wrap #(
+        .DRAMMemBase     (DRAMMemBase),
+        .CapSize         (CapSize),
+        .TagCacheMemBase (TagCacheMemBase),
+        .SetAssociativity(SetAssociativity),
+        .NumLines        (NumLines),
+        .NumBlocks       (NumBlocks),
+        .AxiIdWidth      (ariane_axi_soc::IdWidthSlave),
+        .AxiAddrWidth    (AxiAddrWidth),
+        .AxiDataWidth    (AxiDataWidth),
+        .AxiUserWidth    (AxiUserWidth),
+        .slv_req_t       (ariane_axi_soc::req_slv_t),
+        .slv_resp_t      (ariane_axi_soc::resp_slv_t),
+        .mst_req_t       (axi_mst_req_t),
+        .mst_resp_t      (axi_mst_resp_t),
+        .reg_req_t       (conf_req_t),
+        .reg_resp_t      (conf_rsp_t),
+        .rule_full_t     (rule_full_t),
+        .PrintSramCfg    (1'b0)
+    ) i_axi_tagctrl_reg_wrap_raw (
+        .clk_i              (clk),
+        .rst_ni             (ndmreset_n),
+        .test_i             (1'b0),
+        .slv_req_i          (dram_req),
+        .slv_resp_o         (dram_resp),
+        .mst_req_o          (axi_tag_req),
+        .mst_resp_i         (axi_tag_resp),
+        .conf_req_i         (  /* not used */),
+        .conf_resp_o        (  /* not used */),
+        .cached_start_addr_i(DRAMBase),
+        .cached_end_addr_i  (TagCacheMemBase)
+    );
+  end else begin
+    assign axi_tag_req = dram_req;
+    assign dram_resp = axi_tag_resp;
+  end
 
 `ifdef PROTOCOL_CHECKER
 logic pc_status;

--- a/corev_apu/tb/ariane_testharness.sv
+++ b/corev_apu/tb/ariane_testharness.sv
@@ -417,6 +417,8 @@ module ariane_testharness import cva6_cheri_pkg::*; #(
   logic [AXI_USER_WIDTH-1:0]    wuser;
   logic [AXI_USER_WIDTH-1:0]    ruser;
 
+  localparam AxiCheriExtraIdBits = CVA6Cfg.CheriPresent ? 1 : 0;
+
   axi_riscv_atomics_wrap #(
     .AXI_ADDR_WIDTH ( AXI_ADDRESS_WIDTH            ),
     .AXI_DATA_WIDTH ( AXI_DATA_WIDTH               ),
@@ -434,7 +436,7 @@ module ariane_testharness import cva6_cheri_pkg::*; #(
   AXI_BUS #(
     .AXI_ADDR_WIDTH ( AXI_ADDRESS_WIDTH            ),
     .AXI_DATA_WIDTH ( AXI_DATA_WIDTH               ),
-    .AXI_ID_WIDTH   ( ariane_axi_soc::IdWidthSlave + ((CVA6Cfg.CheriPresent) ? 1 : 0)),
+    .AXI_ID_WIDTH   ( ariane_axi_soc::IdWidthSlave + AxiCheriExtraIdBits ),
     .AXI_USER_WIDTH ( AXI_USER_WIDTH               )
   ) dram_delayed();
 
@@ -445,42 +447,24 @@ module ariane_testharness import cva6_cheri_pkg::*; #(
     .AXI_USER_WIDTH ( AXI_USER_WIDTH               )
   ) tag_mst();
 
-  if (CVA6Cfg.CheriPresent) begin
-    axi_delayer_intf #(
-      .AXI_ID_WIDTH        ( ariane_axi_soc::IdWidthSlave + 1),
-      .AXI_ADDR_WIDTH      ( AXI_ADDRESS_WIDTH            ),
-      .AXI_DATA_WIDTH      ( AXI_DATA_WIDTH               ),
-      .AXI_USER_WIDTH      ( AXI_USER_WIDTH               ),
-      .STALL_RANDOM_INPUT  ( StallRandomInput             ),
-      .STALL_RANDOM_OUTPUT ( StallRandomOutput            ),
-      .FIXED_DELAY_INPUT   ( 0                            ),
-      .FIXED_DELAY_OUTPUT  ( 0                            )
-    ) i_axi_delayer (
-      .clk_i  ( clk_i        ),
-      .rst_ni ( ndmreset_n   ),
-      .slv    ( tag_mst ),
-      .mst    ( dram_delayed )
-    );
-  end else begin
-    axi_delayer_intf #(
-      .AXI_ID_WIDTH        ( ariane_axi_soc::IdWidthSlave ),
-      .AXI_ADDR_WIDTH      ( AXI_ADDRESS_WIDTH            ),
-      .AXI_DATA_WIDTH      ( AXI_DATA_WIDTH               ),
-      .AXI_USER_WIDTH      ( AXI_USER_WIDTH               ),
-      .STALL_RANDOM_INPUT  ( StallRandomInput             ),
-      .STALL_RANDOM_OUTPUT ( StallRandomOutput            ),
-      .FIXED_DELAY_INPUT   ( 0                            ),
-      .FIXED_DELAY_OUTPUT  ( 0                            )
-    ) i_axi_delayer (
-      .clk_i  ( clk_i        ),
-      .rst_ni ( ndmreset_n   ),
-      .slv    ( dram         ),
-      .mst    ( dram_delayed )
-    );
-  end
+  axi_delayer_intf #(
+    .AXI_ID_WIDTH        ( ariane_axi_soc::IdWidthSlave + AxiCheriExtraIdBits ),
+    .AXI_ADDR_WIDTH      ( AXI_ADDRESS_WIDTH            ),
+    .AXI_DATA_WIDTH      ( AXI_DATA_WIDTH               ),
+    .AXI_USER_WIDTH      ( AXI_USER_WIDTH               ),
+    .STALL_RANDOM_INPUT  ( StallRandomInput             ),
+    .STALL_RANDOM_OUTPUT ( StallRandomOutput            ),
+    .FIXED_DELAY_INPUT   ( 0                            ),
+    .FIXED_DELAY_OUTPUT  ( 0                            )
+  ) i_axi_delayer (
+    .clk_i  ( clk_i        ),
+    .rst_ni ( ndmreset_n   ),
+    .slv    ( tag_mst ),
+    .mst    ( dram_delayed )
+  );
 
   axi2mem #(
-    .AXI_ID_WIDTH   ( ariane_axi_soc::IdWidthSlave + ((CVA6Cfg.CheriPresent) ? 1 : 0 )),
+    .AXI_ID_WIDTH   ( ariane_axi_soc::IdWidthSlave + AxiCheriExtraIdBits ),
     .AXI_ADDR_WIDTH ( AXI_ADDRESS_WIDTH            ),
     .AXI_DATA_WIDTH ( AXI_DATA_WIDTH               ),
     .AXI_USER_WIDTH ( AXI_USER_WIDTH               )
@@ -504,7 +488,7 @@ module ariane_testharness import cva6_cheri_pkg::*; #(
     axi_addr_t   end_addr;
   } rule_full_t;
 
-  typedef logic [ariane_axi_soc::IdWidthSlave:0] axi_mst_id_t;
+  typedef logic [(ariane_axi_soc::IdWidthSlave+AxiCheriExtraIdBits)-1:0] axi_mst_id_t;
   typedef logic [CVA6Cfg.AxiDataWidth-1:0] axi_data_t;
   typedef logic [ariane_axi_soc::StrbWidth-1:0] axi_strb_t;
   typedef logic [CVA6Cfg.AxiUserWidth-1:0] axi_user_t;
@@ -523,14 +507,14 @@ module ariane_testharness import cva6_cheri_pkg::*; #(
   ariane_axi_soc::resp_slv_t dram_resp;
   axi_mst_req_t axi_tag_req;
   axi_mst_resp_t axi_tag_resp;
-  if (CVA6Cfg.CheriPresent) begin : gen_cheri_tag_controller
 
-  `AXI_ASSIGN_TO_REQ(dram_req,   dram)
-  `AXI_ASSIGN_FROM_RESP( dram, dram_resp)
+  `AXI_ASSIGN_TO_REQ(dram_req, dram)
+  `AXI_ASSIGN_FROM_RESP(dram, dram_resp)
   `AXI_ASSIGN_FROM_REQ(tag_mst, axi_tag_req)
-  `AXI_ASSIGN_TO_RESP(  axi_tag_resp, tag_mst)
+  `AXI_ASSIGN_TO_RESP(axi_tag_resp, tag_mst)
   `REG_BUS_TYPEDEF_ALL(conf, logic [31:0], logic [31:0], logic [3:0])
 
+  if (CVA6Cfg.CheriPresent) begin : gen_cheri_tag_controller
     axi_tagctrl_reg_wrap #(
         .DRAMMemBase     (ariane_soc::DRAMBase),
         .CapSize         (CVA6Cfg.CLEN),
@@ -563,8 +547,10 @@ module ariane_testharness import cva6_cheri_pkg::*; #(
         .cached_start_addr_i(ariane_soc::DRAMBase),
         .cached_end_addr_i  ({64'hA0000000})
     );
+  end else begin
+    assign axi_tag_req = dram_req;
+    assign dram_resp = axi_tag_resp;
   end
-
 
   sram #(
     .DATA_WIDTH ( AXI_DATA_WIDTH ),
@@ -588,16 +574,6 @@ module ariane_testharness import cva6_cheri_pkg::*; #(
     .ruser_o    ( ruser                                                                       ),
     .rdata_o    ( rdata                                                                       )
   );
-
-  /* cva6_cheri_tag_mem tag_mem (
-    .clk_i        ( clk_i     ),
-    .rst_ni       ( rst_ni    ),
-    .address_i    ( addr      ),
-    .we_i         ( we        ),
-    .writedata_i  ( wuser ),
-    .readdata_o   ( ruser )
-  ); */
-
 
   // ---------------
   // AXI Xbar
@@ -755,7 +731,7 @@ module ariane_testharness import cva6_cheri_pkg::*; #(
   ) i_ariane (
     .clk_i                ( clk_i               ),
     .rst_ni               ( ndmreset_n          ),
-    .boot_addr_i          ( (CVA6Cfg.CheriPresent) ? boot_cap : ariane_soc::ROMBase ), // start fetching from ROM
+    .boot_addr_i          ( CVA6Cfg.CheriPresent ? boot_cap : ariane_soc::ROMBase ), // start fetching from ROM
     .hart_id_i            ( {56'h0, hart_id}    ),
     .irq_i                ( irqs                ),
     .ipi_i                ( ipi                 ),

--- a/corev_apu/tb/tb_testRig_cheri/hdl/ariane_testharness_dii.sv
+++ b/corev_apu/tb/tb_testRig_cheri/hdl/ariane_testharness_dii.sv
@@ -329,6 +329,8 @@ module ariane_testharness_dii import cva6_cheri_pkg::*; #(
   logic [AXI_USER_WIDTH-1:0]    wuser;
   logic [AXI_USER_WIDTH-1:0]    ruser;
 
+  localparam AxiCheriExtraIdBits = CVA6Cfg.CheriPresent ? 1 : 0;
+
   axi_riscv_atomics_wrap #(
     .AXI_ADDR_WIDTH ( AXI_ADDRESS_WIDTH            ),
     .AXI_DATA_WIDTH ( AXI_DATA_WIDTH               ),
@@ -346,7 +348,7 @@ module ariane_testharness_dii import cva6_cheri_pkg::*; #(
   AXI_BUS #(
     .AXI_ADDR_WIDTH ( AXI_ADDRESS_WIDTH            ),
     .AXI_DATA_WIDTH ( AXI_DATA_WIDTH               ),
-    .AXI_ID_WIDTH   ( ariane_axi_soc::IdWidthSlave + ((CVA6Cfg.CheriPresent) ? 1 : 0)),
+    .AXI_ID_WIDTH   ( ariane_axi_soc::IdWidthSlave + AxiCheriExtraIdBits ),
     .AXI_USER_WIDTH ( AXI_USER_WIDTH               )
   ) dram_delayed();
 
@@ -357,42 +359,24 @@ module ariane_testharness_dii import cva6_cheri_pkg::*; #(
     .AXI_USER_WIDTH ( AXI_USER_WIDTH               )
   ) tag_mst();
 
-  if (CVA6Cfg.CheriPresent) begin
-    axi_delayer_intf #(
-      .AXI_ID_WIDTH        ( ariane_axi_soc::IdWidthSlave + 1),
-      .AXI_ADDR_WIDTH      ( AXI_ADDRESS_WIDTH            ),
-      .AXI_DATA_WIDTH      ( AXI_DATA_WIDTH               ),
-      .AXI_USER_WIDTH      ( AXI_USER_WIDTH               ),
-      .STALL_RANDOM_INPUT  ( StallRandomInput             ),
-      .STALL_RANDOM_OUTPUT ( StallRandomOutput            ),
-      .FIXED_DELAY_INPUT   ( 0                            ),
-      .FIXED_DELAY_OUTPUT  ( 0                            )
-    ) i_axi_delayer (
-      .clk_i  ( clk_i        ),
-      .rst_ni ( ndmreset_n   ),
-      .slv    ( tag_mst ),
-      .mst    ( dram_delayed )
-    );
-  end else begin
-    axi_delayer_intf #(
-      .AXI_ID_WIDTH        ( ariane_axi_soc::IdWidthSlave ),
-      .AXI_ADDR_WIDTH      ( AXI_ADDRESS_WIDTH            ),
-      .AXI_DATA_WIDTH      ( AXI_DATA_WIDTH               ),
-      .AXI_USER_WIDTH      ( AXI_USER_WIDTH               ),
-      .STALL_RANDOM_INPUT  ( StallRandomInput             ),
-      .STALL_RANDOM_OUTPUT ( StallRandomOutput            ),
-      .FIXED_DELAY_INPUT   ( 0                            ),
-      .FIXED_DELAY_OUTPUT  ( 0                            )
-    ) i_axi_delayer (
-      .clk_i  ( clk_i        ),
-      .rst_ni ( ndmreset_n   ),
-      .slv    ( dram         ),
-      .mst    ( dram_delayed )
-    );
-  end
+  axi_delayer_intf #(
+    .AXI_ID_WIDTH        ( ariane_axi_soc::IdWidthSlave + AxiCheriExtraIdBits ),
+    .AXI_ADDR_WIDTH      ( AXI_ADDRESS_WIDTH            ),
+    .AXI_DATA_WIDTH      ( AXI_DATA_WIDTH               ),
+    .AXI_USER_WIDTH      ( AXI_USER_WIDTH               ),
+    .STALL_RANDOM_INPUT  ( StallRandomInput             ),
+    .STALL_RANDOM_OUTPUT ( StallRandomOutput            ),
+    .FIXED_DELAY_INPUT   ( 0                            ),
+    .FIXED_DELAY_OUTPUT  ( 0                            )
+  ) i_axi_delayer (
+    .clk_i  ( clk_i        ),
+    .rst_ni ( ndmreset_n   ),
+    .slv    ( tag_mst ),
+    .mst    ( dram_delayed )
+  );
 
   axi2mem #(
-    .AXI_ID_WIDTH   ( ariane_axi_soc::IdWidthSlave + ((CVA6Cfg.CheriPresent) ? 1 : 0 )),
+    .AXI_ID_WIDTH   ( ariane_axi_soc::IdWidthSlave + AxiCheriExtraIdBits ),
     .AXI_ADDR_WIDTH ( AXI_ADDRESS_WIDTH            ),
     .AXI_DATA_WIDTH ( AXI_DATA_WIDTH               ),
     .AXI_USER_WIDTH ( AXI_USER_WIDTH               )
@@ -416,7 +400,7 @@ module ariane_testharness_dii import cva6_cheri_pkg::*; #(
     axi_addr_t   end_addr;
   } rule_full_t;
 
-  typedef logic [ariane_axi_soc::IdWidthSlave:0] axi_mst_id_t;
+  typedef logic [(ariane_axi_soc::IdWidthSlave+AxiCheriExtraIdBits)-1:0] axi_mst_id_t;
   typedef logic [CVA6Cfg.AxiDataWidth-1:0] axi_data_t;
   typedef logic [ariane_axi_soc::StrbWidth-1:0] axi_strb_t;
   typedef logic [CVA6Cfg.AxiUserWidth-1:0] axi_user_t;
@@ -435,14 +419,14 @@ module ariane_testharness_dii import cva6_cheri_pkg::*; #(
   ariane_axi_soc::resp_slv_t dram_resp;
   axi_mst_req_t axi_tag_req;
   axi_mst_resp_t axi_tag_resp;
-  if (CVA6Cfg.CheriPresent) begin : gen_cheri_tag_controller
 
-  `AXI_ASSIGN_TO_REQ(dram_req,   dram)
-  `AXI_ASSIGN_FROM_RESP( dram, dram_resp)
+  `AXI_ASSIGN_TO_REQ(dram_req, dram)
+  `AXI_ASSIGN_FROM_RESP(dram, dram_resp)
   `AXI_ASSIGN_FROM_REQ(tag_mst, axi_tag_req)
-  `AXI_ASSIGN_TO_RESP(  axi_tag_resp, tag_mst)
+  `AXI_ASSIGN_TO_RESP(axi_tag_resp, tag_mst)
   `REG_BUS_TYPEDEF_ALL(conf, logic [31:0], logic [31:0], logic [3:0])
 
+  if (CVA6Cfg.CheriPresent) begin : gen_cheri_tag_controller
     axi_tagctrl_reg_wrap #(
         .DRAMMemBase     (ariane_soc::DRAMBase),
         .CapSize         (CVA6Cfg.CLEN),
@@ -475,8 +459,10 @@ module ariane_testharness_dii import cva6_cheri_pkg::*; #(
         .cached_start_addr_i(ariane_soc::DRAMBase),
         .cached_end_addr_i  (ariane_soc::DRAMBase + 64'h800000)
     );
+  end else begin
+    assign axi_tag_req = dram_req;
+    assign dram_resp = axi_tag_resp;
   end
-
 
   sram #(
     .DATA_WIDTH ( AXI_DATA_WIDTH ),
@@ -500,16 +486,6 @@ module ariane_testharness_dii import cva6_cheri_pkg::*; #(
     .ruser_o    ( ruser                                                                       ),
     .rdata_o    ( rdata                                                                       )
   );
-
-  /* cva6_cheri_tag_mem tag_mem (
-    .clk_i        ( clk_i     ),
-    .rst_ni       ( rst_ni    ),
-    .address_i    ( addr      ),
-    .we_i         ( we        ),
-    .writedata_i  ( wuser ),
-    .readdata_o   ( ruser )
-  ); */
-
 
   // ---------------
   // AXI Xbar
@@ -669,7 +645,7 @@ module ariane_testharness_dii import cva6_cheri_pkg::*; #(
   ) i_ariane (
     .clk_i                ( clk_i               ),
     .rst_ni               ( ndmreset_n          ),
-    .boot_addr_i          ( (CVA6Cfg.CheriPresent) ? boot_cap : boot_addr ), // start fetching from ROM
+    .boot_addr_i          ( CVA6Cfg.CheriPresent ? boot_cap : boot_addr ), // start fetching from ROM
     .hart_id_i            ( {56'h0, hart_id}    ),
     .irq_i                ( irqs                ),
     .ipi_i                ( ipi                 ),


### PR DESCRIPTION
The three different toplevels have evolved different treatments of CHERI parameterisation and the tag controller. Make these all line up.

Of particular note:
 - fix the ID width in the FPGA toplevel.
 - Make the tag controller not synthesise without CHERI in the FPGA toplevel
 - Avoid controlling type declarations inside conditional blocks, which is problematic for some tools