### PR TITLE
[git] Atomics pointed to fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,7 +21,7 @@
 	url = https://github.com/lowRISC/ariane-ethernet.git
 [submodule "corev_apu/src/axi_riscv_atomics"]
 	path = corev_apu/src/axi_riscv_atomics
-	url = https://github.com/pulp-platform/axi_riscv_atomics.git
+	url = https://github.com/ninolomata/axi_riscv_atomics.git
 [submodule "corev_apu/riscv-dbg"]
 	path = corev_apu/riscv-dbg
 	url = https://github.com/pulp-platform/riscv-dbg.git


### PR DESCRIPTION
Previously git submodule initialisation would fail because the commit doesn't exist on the Pulp upstream, but it does exist in the ninolomata fork.