### PR TITLE
Fix default vanilla target in Jenkins builds

### DIFF
--- a/corev_apu/Jenkinsfile
+++ b/corev_apu/Jenkinsfile
@@ -31,8 +31,8 @@ pipeline {
                       fi
                       . /local/ecad/xilinx/Vivado/2020.1/settings64.sh
                       sed "s/\\(ConfigRVZcheri.*\\) = 1/\\1 = 0/" core/include/cv64a6_imafdczcheri_sv39_hpdcache_wb_config_pkg.sv > core/include/cv64a6_imafdczNOcheri_sv39_hpdcache_wb_config_pkg.sv
-                      sed -i -E 's/ConfigDataUserEn = 1/ConfigDataUserEn = 0/' core/include/cv64a6_imafdchzNOcheri_sv39_config_pkg.sv
-                      export target="cv64a6_imafdchzNOcheri_sv39"
+                      sed -i -E 's/ConfigDataUserEn = 1/ConfigDataUserEn = 0/' core/include/cv64a6_imafdczNOcheri_sv39_hpdcache_wb_config_pkg.sv
+                      export target="cv64a6_imafdczNOcheri_sv39_hpdcache_wb"
                       if [ "$flavour" = "CHERI" ]; then
                         export target="cv64a6_imafdczcheri_sv39_hpdcache_wb"
                       fi


### PR DESCRIPTION
A bug snuck in in the Jenkinsfile where it refers to stale config names. This fixes it.