### PR TITLE
Fix some end-of-simulation logic so that exiting the simulation works even without RVFI tracing configured in.

### DIFF
--- a/corev_apu/tb/ariane_testharness.sv
+++ b/corev_apu/tb/ariane_testharness.sv
@@ -144,11 +144,7 @@ module ariane_testharness import cva6_cheri_pkg::*; #(
   assign debug_req_valid     = (jtag_enable[0]) ? jtag_req_valid     : dmi_req_valid;
   assign debug_resp_ready    = (jtag_enable[0]) ? jtag_resp_ready    : dmi_resp_ready;
   assign debug_req           = (jtag_enable[0]) ? jtag_dmi_req       : dmi_req;
-  if (ariane_pkg::RVFI) begin
-    assign exit_o              = (jtag_enable[0]) ? jtag_exit          : rvfi_exit;
-  end else begin
-    assign exit_o              = (jtag_enable[0]) ? jtag_exit          : dmi_exit;
-  end
+  assign exit_o              = (jtag_enable[0]) ? jtag_exit          : (dmi_exit | rvfi_exit);
   assign jtag_resp_valid     = (jtag_enable[0]) ? debug_resp_valid   : 1'b0;
   assign dmi_resp_valid      = (jtag_enable[0]) ? 1'b0               : debug_resp_valid;
 
@@ -944,11 +940,14 @@ module ariane_testharness import cva6_cheri_pkg::*; #(
             tandem_timeout <= tandem_timeout + 1;
     end
 
-    always_ff @(posedge clk_i) begin
-        if (tandem_exit || (tandem_timeout > TANDEM_TIMEOUT_THRESHOLD)) begin
-            rvfi_exit <= tracer_exit;
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+        if (!rst_ni) begin
+            rvfi_exit <= 0;
+        end else begin
+            if (tandem_exit || (tandem_timeout > TANDEM_TIMEOUT_THRESHOLD)) begin
+              rvfi_exit <= tracer_exit;
+            end
         end
-
     end
 `else
     assign rvfi_exit = tracer_exit;

--- a/corev_apu/tb/rvfi_tracer.sv
+++ b/corev_apu/tb/rvfi_tracer.sv
@@ -67,9 +67,6 @@ module rvfi_tracer #(
   final $fclose(f);
 
   logic [31:0] cycles;
-  // Generate the trace based on RVFI
-  logic [63:0] pc64;
-  string cause;
   logic[31:0] end_of_test_d;
   logic[31:0] end_of_test_q;
 
@@ -134,10 +131,10 @@ module rvfi_tracer #(
       end_of_test_q <= end_of_test_d;
 
       for (int i = 0; i < CVA6Cfg.NrCommitPorts; i++) begin
-        pc64 = {{CVA6Cfg.XLEN-CVA6Cfg.VLEN{rvfi_i[i].pc_rdata[CVA6Cfg.VLEN-1]}}, rvfi_i[i].pc_rdata};
+        automatic logic [63:0] pc64 = {{CVA6Cfg.XLEN-CVA6Cfg.VLEN{rvfi_i[i].pc_rdata[CVA6Cfg.VLEN-1]}}, rvfi_i[i].pc_rdata};
         // print the instruction information if the instruction is valid or a trap is taken
         if (rvfi_i[i].valid) begin
-          logic dest_is_fp;
+          automatic logic dest_is_fp;
           // Instruction information
           if (rvfi_i[i].intr[2]) begin
             $fwrite(f, "core   INTERRUPT 0: 0x%h (0x%h) DASM(%h)\n",
@@ -190,6 +187,7 @@ module rvfi_tracer #(
           $fwrite(f, "\n");
         end else begin
           if (rvfi_i[i].trap) begin
+            automatic string cause;
             case (rvfi_i[i].cause)
               32'h0: cause = "INSTR_ADDR_MISALIGNED";
               32'h1: cause = "INSTR_ACCESS_FAULT";

--- a/corev_apu/tb/rvfi_tracer.sv
+++ b/corev_apu/tb/rvfi_tracer.sv
@@ -110,83 +110,12 @@ module rvfi_tracer #(
 
   always_comb begin
     for (int i = 0; i < CVA6Cfg.NrCommitPorts; i++) begin
-      pc64 = {{CVA6Cfg.XLEN-CVA6Cfg.VLEN{rvfi_i[i].pc_rdata[CVA6Cfg.VLEN-1]}}, rvfi_i[i].pc_rdata};
-      // print the instruction information if the instruction is valid or a trap is taken
       if (rvfi_i[i].valid) begin
-        logic dest_is_fp;
-        // Instruction information
-        if (rvfi_i[i].intr[2]) begin
-           $fwrite(f, "core   INTERRUPT 0: 0x%h (0x%h) DASM(%h)\n",
-             pc64, rvfi_i[i].insn, rvfi_i[i].insn);
-        end
-        else begin
-           $fwrite(f, "core   0: 0x%h (0x%h) DASM(%h)\n",
-             pc64, rvfi_i[i].insn, rvfi_i[i].insn);
-        end
-        // Destination register information
-        if (rvfi_i[i].insn[1:0] != 2'b11) begin
-          $fwrite(f, "%h 0x%h (0x%h)",
-            rvfi_i[i].mode, pc64, rvfi_i[i].insn[15:0]);
-        end else begin
-          $fwrite(f, "%h 0x%h (0x%h)",
-            rvfi_i[i].mode, pc64, rvfi_i[i].insn);
-        end
-        // Decode instruction to know if destination register is FP register.
-        // Handle both uncompressed and compressed instructions.
-        dest_is_fp = 1'b0;
-        if ( rvfi_i[i].insn[6:0] == 7'b1001111 ||
-             rvfi_i[i].insn[6:0] == 7'b1001011 ||
-             rvfi_i[i].insn[6:0] == 7'b1000111 ||
-             rvfi_i[i].insn[6:0] == 7'b1000011 ||
-             rvfi_i[i].insn[6:0] == 7'b0000111 ||
-            (rvfi_i[i].insn[6:0] == 7'b1010011 && rvfi_i[i].insn[31:26] != 6'b111000
-                                               && rvfi_i[i].insn[31:26] != 6'b101000
-                                               && rvfi_i[i].insn[31:26] != 6'b110000) ||
-            (rvfi_i[i].insn[0] == 1'b0 && ((rvfi_i[i].insn[15:13] == 3'b001 && CVA6Cfg.XLEN == 64) ||
-                                           (rvfi_i[i].insn[15:13] == 3'b011 && CVA6Cfg.XLEN == 32) ))) begin
-          if (fp_instr_writes_gpr(rvfi_i[i].insn)) begin
-            dest_is_fp = 1'b0;
-          end else begin
-            dest_is_fp = 1'b1;
-          end
-        end
-
-        if (dest_is_fp) begin
-          $fwrite(f, " f%d 0x%h", rvfi_i[i].rd_addr, rvfi_i[i].rd_wdata);
-        end else if (rvfi_i[i].rd_addr != 0) begin
-          $fwrite(f, " x%d 0x%h", rvfi_i[i].rd_addr, rvfi_i[i].rd_wdata);
-          if (rvfi_i[i].mem_rmask != 0) begin
-            $fwrite(f, " mem 0x%h", rvfi_i[i].mem_addr);
-          end
-        end else begin
-          if (rvfi_i[i].mem_wmask != 0) begin
-            $fwrite(f, " mem 0x%h 0x%h", rvfi_i[i].mem_addr, rvfi_i[i].mem_wdata);
-            if (TOHOST_ADDR != '0 &&
-                rvfi_i[i].mem_paddr == TOHOST_ADDR &&
-                rvfi_i[i].mem_wdata[0] == 1'b1) begin
-              end_of_test_d = rvfi_i[i].mem_wdata[31:0];
-              $display("*** [rvfi_tracer] INFO: Simulation terminated after %d cycles!\n", cycles);
-            end
-          end
-        end
-        $fwrite(f, "\n");
-      end else begin
-        if (rvfi_i[i].trap) begin
-          case (rvfi_i[i].cause)
-            32'h0: cause = "INSTR_ADDR_MISALIGNED";
-            32'h1: cause = "INSTR_ACCESS_FAULT";
-            32'h2: cause = "ILLEGAL_INSTR";
-            32'h3: cause = "BREAKPOINT";
-            32'h4: cause = "LD_ADDR_MISALIGNED";
-            32'h5: cause = "LD_ACCESS_FAULT";
-            32'h6: cause = "ST_ADDR_MISALIGNED";
-            32'h7: cause = "ST_ACCESS_FAULT";
-            32'hb: cause = "ENV_CALL_MMODE";
-          endcase;
-          if (rvfi_i[i].insn[1:0] != 2'b11) begin
-            $fwrite(f, "%s exception @ 0x%h (0x%h)\n", cause, pc64, rvfi_i[i].insn[15:0]);
-          end else begin
-            $fwrite(f, "%s exception @ 0x%h (0x%h)\n", cause, pc64, rvfi_i[i].insn);
+        if (rvfi_i[i].mem_wmask != 0) begin
+          if (TOHOST_ADDR != '0 &&
+              rvfi_i[i].mem_paddr == TOHOST_ADDR &&
+              rvfi_i[i].mem_wdata[0] == 1'b1) begin
+            end_of_test_d = rvfi_i[i].mem_wdata[31:0];
           end
         end
       end
@@ -203,6 +132,83 @@ module rvfi_tracer #(
     end else begin
       cycles <= cycles+1;
       end_of_test_q <= end_of_test_d;
+
+      for (int i = 0; i < CVA6Cfg.NrCommitPorts; i++) begin
+        pc64 = {{CVA6Cfg.XLEN-CVA6Cfg.VLEN{rvfi_i[i].pc_rdata[CVA6Cfg.VLEN-1]}}, rvfi_i[i].pc_rdata};
+        // print the instruction information if the instruction is valid or a trap is taken
+        if (rvfi_i[i].valid) begin
+          logic dest_is_fp;
+          // Instruction information
+          if (rvfi_i[i].intr[2]) begin
+            $fwrite(f, "core   INTERRUPT 0: 0x%h (0x%h) DASM(%h)\n",
+              pc64, rvfi_i[i].insn, rvfi_i[i].insn);
+          end
+          else begin
+            $fwrite(f, "core   0: 0x%h (0x%h) DASM(%h)\n",
+              pc64, rvfi_i[i].insn, rvfi_i[i].insn);
+          end
+          // Destination register information
+          if (rvfi_i[i].insn[1:0] != 2'b11) begin
+            $fwrite(f, "%h 0x%h (0x%h)",
+              rvfi_i[i].mode, pc64, rvfi_i[i].insn[15:0]);
+          end else begin
+            $fwrite(f, "%h 0x%h (0x%h)",
+              rvfi_i[i].mode, pc64, rvfi_i[i].insn);
+          end
+          // Decode instruction to know if destination register is FP register.
+          // Handle both uncompressed and compressed instructions.
+          dest_is_fp = 1'b0;
+          if ( rvfi_i[i].insn[6:0] == 7'b1001111 ||
+              rvfi_i[i].insn[6:0] == 7'b1001011 ||
+              rvfi_i[i].insn[6:0] == 7'b1000111 ||
+              rvfi_i[i].insn[6:0] == 7'b1000011 ||
+              rvfi_i[i].insn[6:0] == 7'b0000111 ||
+              (rvfi_i[i].insn[6:0] == 7'b1010011 && rvfi_i[i].insn[31:26] != 6'b111000
+                                                && rvfi_i[i].insn[31:26] != 6'b101000
+                                                && rvfi_i[i].insn[31:26] != 6'b110000) ||
+              (rvfi_i[i].insn[0] == 1'b0 && ((rvfi_i[i].insn[15:13] == 3'b001 && CVA6Cfg.XLEN == 64) ||
+                                            (rvfi_i[i].insn[15:13] == 3'b011 && CVA6Cfg.XLEN == 32) ))) begin
+            if (fp_instr_writes_gpr(rvfi_i[i].insn)) begin
+              dest_is_fp = 1'b0;
+            end else begin
+              dest_is_fp = 1'b1;
+            end
+          end
+
+          if (dest_is_fp) begin
+            $fwrite(f, " f%d 0x%h", rvfi_i[i].rd_addr, rvfi_i[i].rd_wdata);
+          end else if (rvfi_i[i].rd_addr != 0) begin
+            $fwrite(f, " x%d 0x%h", rvfi_i[i].rd_addr, rvfi_i[i].rd_wdata);
+            if (rvfi_i[i].mem_rmask != 0) begin
+              $fwrite(f, " mem 0x%h", rvfi_i[i].mem_addr);
+            end
+          end else begin
+            if (rvfi_i[i].mem_wmask != 0) begin
+              $fwrite(f, " mem 0x%h 0x%h", rvfi_i[i].mem_addr, rvfi_i[i].mem_wdata);
+            end
+          end
+          $fwrite(f, "\n");
+        end else begin
+          if (rvfi_i[i].trap) begin
+            case (rvfi_i[i].cause)
+              32'h0: cause = "INSTR_ADDR_MISALIGNED";
+              32'h1: cause = "INSTR_ACCESS_FAULT";
+              32'h2: cause = "ILLEGAL_INSTR";
+              32'h3: cause = "BREAKPOINT";
+              32'h4: cause = "LD_ADDR_MISALIGNED";
+              32'h5: cause = "LD_ACCESS_FAULT";
+              32'h6: cause = "ST_ADDR_MISALIGNED";
+              32'h7: cause = "ST_ACCESS_FAULT";
+              32'hb: cause = "ENV_CALL_MMODE";
+            endcase;
+            if (rvfi_i[i].insn[1:0] != 2'b11) begin
+              $fwrite(f, "%s exception @ 0x%h (0x%h)\n", cause, pc64, rvfi_i[i].insn[15:0]);
+            end else begin
+              $fwrite(f, "%s exception @ 0x%h (0x%h)\n", cause, pc64, rvfi_i[i].insn);
+            end
+          end
+        end
+      end
     end
   end
 

--- a/corev_apu/tb/rvfi_tracer.sv
+++ b/corev_apu/tb/rvfi_tracer.sv
@@ -70,8 +70,8 @@ module rvfi_tracer #(
   // Generate the trace based on RVFI
   logic [63:0] pc64;
   string cause;
-  logic[31:0] end_of_test_q;
   logic[31:0] end_of_test_d;
+  logic[31:0] end_of_test_q;
 
   function automatic logic fp_instr_writes_gpr(logic [31:0] insn);
     logic [6:0] opcode;
@@ -106,10 +106,9 @@ module rvfi_tracer #(
     return 1'b0;
   endfunction
 
-  assign end_of_test_o = end_of_test_d;
+  assign end_of_test_o = end_of_test_q;
 
-  always_ff @(posedge clk_i) begin
-    end_of_test_q <= (rst_ni && (end_of_test_d[0] == 1'b1)) ? end_of_test_d : 0;
+  always_comb begin
     for (int i = 0; i < CVA6Cfg.NrCommitPorts; i++) begin
       pc64 = {{CVA6Cfg.XLEN-CVA6Cfg.VLEN{rvfi_i[i].pc_rdata[CVA6Cfg.VLEN-1]}}, rvfi_i[i].pc_rdata};
       // print the instruction information if the instruction is valid or a trap is taken
@@ -165,7 +164,7 @@ module rvfi_tracer #(
             if (TOHOST_ADDR != '0 &&
                 rvfi_i[i].mem_paddr == TOHOST_ADDR &&
                 rvfi_i[i].mem_wdata[0] == 1'b1) begin
-              end_of_test_q <= rvfi_i[i].mem_wdata[31:0];
+              end_of_test_d = rvfi_i[i].mem_wdata[31:0];
               $display("*** [rvfi_tracer] INFO: Simulation terminated after %d cycles!\n", cycles);
             end
           end
@@ -193,14 +192,18 @@ module rvfi_tracer #(
       end
     end
 
-    if (~rst_ni)
-      cycles <= 0;
-    else
-      cycles <= cycles+1;
     if (cycles > SIM_FINISH)
-      end_of_test_q <= 32'hffff_ffff;
+      end_of_test_d = 32'hffff_ffff;
+  end
 
-    end_of_test_d <= end_of_test_q;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (~rst_ni) begin
+      cycles <= 0;
+      end_of_test_q <= 0;
+    end else begin
+      cycles <= cycles+1;
+      end_of_test_q <= end_of_test_d;
+    end
   end
 
 


### PR DESCRIPTION
Some amount of RVFI infrastructure appears to be included even when RVFI is not configured in, which is perhaps concerning.