### PR TITLE
Add CHERI CI support and enable scalar crypto support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix:
         testcase:  [ cv64a6_imafdc_tests ]
-        config:    [ cv64a6_imafdc_sv39_hpdcache, cv64a6_imafdc_sv39_hpdcache_wb, cv64a6_imafdc_sv39_wb, cv64a6_imafdc_sv39 ]
+        config:    [ cv64a6_imafdc_sv39_hpdcache, cv64a6_imafdc_sv39_hpdcache_wb, cv64a6_imafdczcheri_sv39_hpdcache_wb, cv64a6_imafdc_sv39_wb, cv64a6_imafdc_sv39, cv64a6_imafdczcheri_sv39 ]
         simulator: [ veri-testharness ]
         include:
           - testcase: dv-riscv-arch-test
@@ -71,6 +71,9 @@ jobs:
             simulator: veri-testharness
           - testcase: dv-riscv-arch-test
             config: cv64a6_imafdc_sv39_hpdcache_wb
+            simulator: veri-testharness
+          - testcase: dv-riscv-arch-test
+            config: cv64a6_imafdczcheri_sv39_hpdcache_wb
             simulator: veri-testharness
     needs:
       build-riscv-tests

--- a/core/aes.sv
+++ b/core/aes.sv
@@ -23,17 +23,17 @@ module aes
     input  logic                        rst_ni,
     // FU data needed to execute instruction - ISSUE_STAGE
     input  fu_data_t                    fu_data_i,
-    // Original instruction bits for aes
-    input  logic     [             5:0] orig_instr_aes,
     // AES result - ISSUE_STAGE
     output logic     [CVA6Cfg.XLEN-1:0] result_o
 );
 
   logic [CVA6Cfg.XLEN-1:0] operand_a;
   logic [CVA6Cfg.XLEN-1:0] operand_b;
+  logic [             5:0] orig_instr_aes;
 
   assign operand_a = reg_to_x(fu_data_i.operand_a);
   assign operand_b = reg_to_x(fu_data_i.operand_b);
+  assign orig_instr_aes = fu_data_i.orig_instr_aes_bits;
 
   logic [63:0] sr;
   logic [ 7:0] sbox_in;

--- a/core/aes.sv
+++ b/core/aes.sv
@@ -29,6 +29,12 @@ module aes
     output logic     [CVA6Cfg.XLEN-1:0] result_o
 );
 
+  logic [CVA6Cfg.XLEN-1:0] operand_a;
+  logic [CVA6Cfg.XLEN-1:0] operand_b;
+
+  assign operand_a = reg_to_x(fu_data_i.operand_a);
+  assign operand_b = reg_to_x(fu_data_i.operand_b);
+
   logic [63:0] sr;
   logic [ 7:0] sbox_in;
   logic [31:0] aes32esi_gen;
@@ -64,67 +70,67 @@ module aes
   // AES gen block
   if (CVA6Cfg.ZKN && CVA6Cfg.RVB) begin : aes_gen_block
     // SHA256 sigma0 transformation function by rotating, shifting and XORing rs1
-    assign sha256sig0_gen = (fu_data_i.operand_a[31:0] >> 7 | fu_data_i.operand_a[31:0] << 25) ^ (fu_data_i.operand_a[31:0] >> 18 | fu_data_i.operand_a[31:0] << 14) ^ (fu_data_i.operand_a[31:0] >> 3);
+    assign sha256sig0_gen = (operand_a[31:0] >> 7 | operand_a[31:0] << 25) ^ (operand_a[31:0] >> 18 | operand_a[31:0] << 14) ^ (operand_a[31:0] >> 3);
     // SHA256 sigma1 transformation function by rotating, shifting and XORing rs1
-    assign sha256sig1_gen = (fu_data_i.operand_a[31:0] >> 17 | fu_data_i.operand_a[31:0] << 15) ^ (fu_data_i.operand_a[31:0] >> 19 | fu_data_i.operand_a[31:0] << 13) ^ (fu_data_i.operand_a[31:0] >> 10);
+    assign sha256sig1_gen = (operand_a[31:0] >> 17 | operand_a[31:0] << 15) ^ (operand_a[31:0] >> 19 | operand_a[31:0] << 13) ^ (operand_a[31:0] >> 10);
     // SHA256 sum0 transformation function by rotating, shifting and XORing rs1
-    assign sha256sum0_gen = (fu_data_i.operand_a[31:0] >> 2 | fu_data_i.operand_a[31:0] << 30) ^ (fu_data_i.operand_a[31:0] >> 13 | fu_data_i.operand_a[31:0] << 19) ^ (fu_data_i.operand_a[31:0] >> 22 | fu_data_i.operand_a[31:0] << 10);
+    assign sha256sum0_gen = (operand_a[31:0] >> 2 | operand_a[31:0] << 30) ^ (operand_a[31:0] >> 13 | operand_a[31:0] << 19) ^ (operand_a[31:0] >> 22 | operand_a[31:0] << 10);
     // SHA256 sum1 transformation function by rotating, shifting and XORing rs1
-    assign sha256sum1_gen = (fu_data_i.operand_a[31:0] >> 6 | fu_data_i.operand_a[31:0] << 26) ^ (fu_data_i.operand_a[31:0] >> 11 | fu_data_i.operand_a[31:0] << 21) ^ (fu_data_i.operand_a[31:0] >> 25 | fu_data_i.operand_a[31:0] << 7);
+    assign sha256sum1_gen = (operand_a[31:0] >> 6 | operand_a[31:0] << 26) ^ (operand_a[31:0] >> 11 | operand_a[31:0] << 21) ^ (operand_a[31:0] >> 25 | operand_a[31:0] << 7);
     if (CVA6Cfg.IS_XLEN32) begin
-      assign sbox_in = fu_data_i.operand_b >> {orig_instr_aes[5:4], 3'b000};
+      assign sbox_in = operand_b >> {orig_instr_aes[5:4], 3'b000};
       // AES 32-bit final round encryption by applying rotations and the forward sbox to a single byte of rs2 based on the MSB byte of the instruction itself  
-      assign aes32esi_gen = (fu_data_i.operand_a ^ ({24'b0, aes_sbox_fwd(
+      assign aes32esi_gen = (operand_a ^ ({24'b0, aes_sbox_fwd(
           sbox_in[7:0]
       )} << {orig_instr_aes[5:4], 3'b000}) | ({24'b0, aes_sbox_fwd(
           sbox_in[7:0]
       )} >> (32 - {orig_instr_aes[5:4], 3'b000})));
       // AES 32-bit middle round encryption by applying rotations, forward mix-columns and the forward sbox to a single byte of rs2 based on the MSB byte of the instruction itself
-      assign aes32esmi_gen = fu_data_i.operand_a ^ ((aes_mixcolumn_fwd(
+      assign aes32esmi_gen = operand_a ^ ((aes_mixcolumn_fwd(
           {24'h000000, aes_sbox_fwd(sbox_in[7:0])}
       ) << {orig_instr_aes[5:4], 3'b000}) | (aes_mixcolumn_fwd(
           {24'h000000, aes_sbox_fwd(sbox_in[7:0])}
       ) >> (32 - {orig_instr_aes[5:4], 3'b000})));
       // AES 32-bit final round decryption by applying rotations and the inverse sbox to a single byte of rs2 based on the MSB byte of the instruction itself
-      assign aes32dsi_gen = (fu_data_i.operand_a ^ ({24'b0, aes_sbox_inv(
+      assign aes32dsi_gen = (operand_a ^ ({24'b0, aes_sbox_inv(
           sbox_in[7:0]
       )} << {orig_instr_aes[5:4], 3'b000}) | ({24'b0, aes_sbox_inv(
           sbox_in[7:0]
       )} >> (32 - {orig_instr_aes[5:4], 3'b000})));
       // AES 32-bit middle round decryption by applying rotations, inverse mix-columns and the inverse sbox to a single byte of rs2 based on the MSB byte of the instruction itself
-      assign aes32dsmi_gen = fu_data_i.operand_a ^ ((aes_mixcolumn_inv(
+      assign aes32dsmi_gen = operand_a ^ ((aes_mixcolumn_inv(
           {24'h000000, aes_sbox_inv(sbox_in[7:0])}
       ) << {orig_instr_aes[5:4], 3'b000}) | (aes_mixcolumn_inv(
           {24'h000000, aes_sbox_inv(sbox_in[7:0])}
       ) >> (32 - {orig_instr_aes[5:4], 3'b000})));
       // SHA512 32-bit shifting and XORing rs1 and rs2
-      assign sha512sig0h_gen = (fu_data_i.operand_a >> 1) ^ (fu_data_i.operand_a >> 7) ^ (fu_data_i.operand_a >> 8) ^ (fu_data_i.operand_b << 31) ^ (fu_data_i.operand_b << 24);
-      assign sha512sig0l_gen = (fu_data_i.operand_a >> 1) ^ (fu_data_i.operand_a >> 7) ^ (fu_data_i.operand_a >> 8) ^ (fu_data_i.operand_b << 31) ^ (fu_data_i.operand_b << 25) ^ (fu_data_i.operand_b << 24);
-      assign sha512sig1h_gen = (fu_data_i.operand_a << 3) ^ (fu_data_i.operand_a >> 6) ^ (fu_data_i.operand_a >> 19) ^ (fu_data_i.operand_b >> 29) ^ (fu_data_i.operand_b << 13);
-      assign sha512sig1l_gen = (fu_data_i.operand_a << 3) ^ (fu_data_i.operand_a >> 6) ^ (fu_data_i.operand_a >> 19) ^ (fu_data_i.operand_b >> 29) ^ (fu_data_i.operand_b << 26) ^ (fu_data_i.operand_b << 13);
-      assign sha512sum0r_gen = (fu_data_i.operand_a << 25) ^ (fu_data_i.operand_a << 30) ^ (fu_data_i.operand_a >> 28) ^ (fu_data_i.operand_b >> 7) ^ (fu_data_i.operand_b >> 2) ^ (fu_data_i.operand_b << 4);
-      assign sha512sum1r_gen = (fu_data_i.operand_a << 23) ^ (fu_data_i.operand_a >> 14) ^ (fu_data_i.operand_a >> 18) ^ (fu_data_i.operand_b >> 9) ^ (fu_data_i.operand_b << 18) ^ (fu_data_i.operand_b << 14);
+      assign sha512sig0h_gen = (operand_a >> 1) ^ (operand_a >> 7) ^ (operand_a >> 8) ^ (operand_b << 31) ^ (operand_b << 24);
+      assign sha512sig0l_gen = (operand_a >> 1) ^ (operand_a >> 7) ^ (operand_a >> 8) ^ (operand_b << 31) ^ (operand_b << 25) ^ (operand_b << 24);
+      assign sha512sig1h_gen = (operand_a << 3) ^ (operand_a >> 6) ^ (operand_a >> 19) ^ (operand_b >> 29) ^ (operand_b << 13);
+      assign sha512sig1l_gen = (operand_a << 3) ^ (operand_a >> 6) ^ (operand_a >> 19) ^ (operand_b >> 29) ^ (operand_b << 26) ^ (operand_b << 13);
+      assign sha512sum0r_gen = (operand_a << 25) ^ (operand_a << 30) ^ (operand_a >> 28) ^ (operand_b >> 7) ^ (operand_b >> 2) ^ (operand_b << 4);
+      assign sha512sum1r_gen = (operand_a << 23) ^ (operand_a >> 14) ^ (operand_a >> 18) ^ (operand_b >> 9) ^ (operand_b << 18) ^ (operand_b << 14);
     end else if (CVA6Cfg.IS_XLEN64) begin
       // AES Shift rows forward and inverse step
       assign sr = {
-        fu_data_i.operand_a[31:24],
-        fu_data_i.operand_b[55:48],
-        fu_data_i.operand_b[15:8],
-        fu_data_i.operand_a[39:32],
-        fu_data_i.operand_b[63:56],
-        fu_data_i.operand_b[23:16],
-        fu_data_i.operand_a[47:40],
-        fu_data_i.operand_a[7:0]
+        operand_a[31:24],
+        operand_b[55:48],
+        operand_b[15:8],
+        operand_a[39:32],
+        operand_b[63:56],
+        operand_b[23:16],
+        operand_a[47:40],
+        operand_a[7:0]
       };
       assign sr_inv = {
-        fu_data_i.operand_b[31:24],
-        fu_data_i.operand_b[55:48],
-        fu_data_i.operand_a[15:8],
-        fu_data_i.operand_a[39:32],
-        fu_data_i.operand_a[63:56],
-        fu_data_i.operand_b[23:16],
-        fu_data_i.operand_b[47:40],
-        fu_data_i.operand_a[7:0]
+        operand_b[31:24],
+        operand_b[55:48],
+        operand_a[15:8],
+        operand_a[39:32],
+        operand_a[63:56],
+        operand_b[23:16],
+        operand_b[47:40],
+        operand_a[7:0]
       };
       // AES 64-bit final round encryption by applying forward shift-rows and the forward sbox to each byte
       assign aes64es_gen = {
@@ -158,28 +164,28 @@ module aes
       };
       // AES 64-bit keySchedule decryption by applying inverse mix-columns on rs1 
       assign aes64im_gen = {
-        aes_mixcolumn_inv(fu_data_i.operand_a[63:32]), aes_mixcolumn_inv(fu_data_i.operand_a[31:0])
+        aes_mixcolumn_inv(operand_a[63:32]), aes_mixcolumn_inv(operand_a[31:0])
       };
       // AES Key Schedule part by XORing different slices of rs1 and rs2 
       assign aes64ks2_gen = {
-        (fu_data_i.operand_a[63:32] ^ fu_data_i.operand_b[31:0] ^ fu_data_i.operand_b[63:32]),
-        (fu_data_i.operand_a[63:32] ^ fu_data_i.operand_b[31:0])
+        (operand_a[63:32] ^ operand_b[31:0] ^ operand_b[63:32]),
+        (operand_a[63:32] ^ operand_b[31:0])
       };
       // AES Key Schedule part by substituting round constant based on round number(from instruction), rotations and forward subword substitutions
       assign aes64ks1i_gen = (orig_instr_aes[3:0] <= 4'hA) ? {((aes_subword_fwd(
-          (orig_instr_aes[3:0] == 4'hA) ? fu_data_i.operand_a[63:32] : ((fu_data_i.operand_a[63:32] >> 8) | (fu_data_i.operand_a[63:32] << 24))
+          (orig_instr_aes[3:0] == 4'hA) ? operand_a[63:32] : ((operand_a[63:32] >> 8) | (operand_a[63:32] << 24))
       )) ^ (aes_decode_rcon(
           orig_instr_aes[3:0]
       ))), ((aes_subword_fwd(
-          (orig_instr_aes[3:0] == 4'hA) ? fu_data_i.operand_a[63:32] : ((fu_data_i.operand_a[63:32] >> 8) | (fu_data_i.operand_a[63:32] << 24))
+          (orig_instr_aes[3:0] == 4'hA) ? operand_a[63:32] : ((operand_a[63:32] >> 8) | (operand_a[63:32] << 24))
       )) ^ (aes_decode_rcon(
           orig_instr_aes[3:0]
       )))} : 64'h0;
       // SHA512 64bit rotating, shifting and XORing rs1
-      assign sha512sig0_gen = (fu_data_i.operand_a >> 1 | fu_data_i.operand_a << 63) ^ (fu_data_i.operand_a >> 8 | fu_data_i.operand_a << 56) ^ (fu_data_i.operand_a >> 7);
-      assign sha512sig1_gen = (fu_data_i.operand_a >> 19 | fu_data_i.operand_a << 45) ^ (fu_data_i.operand_a >> 61 | fu_data_i.operand_a << 3) ^ (fu_data_i.operand_a >> 6);
-      assign sha512sum0_gen = (fu_data_i.operand_a >> 28 | fu_data_i.operand_a << 36) ^ (fu_data_i.operand_a >> 34 | fu_data_i.operand_a << 30) ^ (fu_data_i.operand_a >> 39 | fu_data_i.operand_a << 25);
-      assign sha512sum1_gen = (fu_data_i.operand_a >> 14 | fu_data_i.operand_a << 50) ^ (fu_data_i.operand_a >> 18 | fu_data_i.operand_a << 46) ^ (fu_data_i.operand_a >> 41 | fu_data_i.operand_a << 23);
+      assign sha512sig0_gen = (operand_a >> 1 | operand_a << 63) ^ (operand_a >> 8 | operand_a << 56) ^ (operand_a >> 7);
+      assign sha512sig1_gen = (operand_a >> 19 | operand_a << 45) ^ (operand_a >> 61 | operand_a << 3) ^ (operand_a >> 6);
+      assign sha512sum0_gen = (operand_a >> 28 | operand_a << 36) ^ (operand_a >> 34 | operand_a << 30) ^ (operand_a >> 39 | operand_a << 25);
+      assign sha512sum1_gen = (operand_a >> 14 | operand_a << 50) ^ (operand_a >> 18 | operand_a << 46) ^ (operand_a >> 41 | operand_a << 23);
     end
   end
 

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -195,6 +195,7 @@ module cva6
       logic [REG_ADDR_SIZE-1:0]         rs2;
       logic [CVA6Cfg.TRANS_ID_BITS-1:0] trans_id;
       logic                             use_ddc;
+      logic [5:0]                       orig_instr_aes_bits;
     },
 
     localparam type icache_req_t = struct packed {

--- a/core/cva6_rvfi.sv
+++ b/core/cva6_rvfi.sv
@@ -352,9 +352,9 @@ module cva6_rvfi
       ) && wdata[i] == 1) ? '0 : commit_instr_rs1[i];
       rvfi_instr_o[i].rs2_addr <= rs2_addr;
       rvfi_instr_o[i].rd_addr <= rd_addr;
-      rvfi_instr_o[i].rd_wdata <= (rd_addr == 0) ? '0 : (CVA6Cfg.FpPresent && is_rd_fpr(
+      rvfi_instr_o[i].rd_wdata <= (CVA6Cfg.FpPresent && is_rd_fpr(
           commit_instr_op[i]
-      )) ? commit_instr_result[i] : wdata[i];
+      )) ? commit_instr_result[i] : (rd_addr == 0) ? '0 : wdata[i];
       rvfi_instr_o[i].pc_rdata <= commit_instr_pc[i];
       if (commit_instr == 32'h30200073 && !exception) begin
         rvfi_instr_o[i].pc_wdata <= csr.mepc_q[63:0];

--- a/core/ex_stage.sv
+++ b/core/ex_stage.sv
@@ -781,9 +781,8 @@ module ex_stage
       ) aes_i (
           .clk_i,
           .rst_ni,
-          .fu_data_i     (one_cycle_data),
-          .result_o      (aes_result),
-          .orig_instr_aes(orig_instr_aes_i)
+          .fu_data_i(one_cycle_data),
+          .result_o (aes_result)
       );
     end else begin : no_aes_gen
       assign aes_result = '0;

--- a/core/ex_stage.sv
+++ b/core/ex_stage.sv
@@ -420,7 +420,7 @@ module ex_stage
       end
       flu_trans_id_o = mult_trans_id;
     end else if (|aes_valid_i) begin
-      flu_result_o = aes_result;
+      flu_result_o = x_to_reg(aes_result);
     end else if (|clu_valid_i) begin
       flu_result_o = clu_result;
     end

--- a/core/ex_stage.sv
+++ b/core/ex_stage.sv
@@ -412,12 +412,7 @@ module ex_stage
     end else if (|csr_valid_i) begin
       flu_result_o = csr_result;
     end else if (mult_valid) begin
-      if (CVA6Cfg.CheriPresent) begin
-        result = cva6_cheri_pkg::set_cap_reg_addr(result, mult_result);
-        flu_result_o = result;
-      end else begin
-        flu_result_o = {{(CVA6Cfg.REGLEN - CVA6Cfg.XLEN) {1'b0}}, mult_result};
-      end
+      flu_result_o   = x_to_reg(mult_result);
       flu_trans_id_o = mult_trans_id;
     end else if (|aes_valid_i) begin
       flu_result_o = x_to_reg(aes_result);

--- a/core/include/cv64a6_imafdc_sv39_rvfi_dii_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_rvfi_dii_config_pkg.sv
@@ -98,7 +98,7 @@ package cva6_config_pkg;
       XF8: bit'(CVA6ConfigF8En),
       RVA: bit'(CVA6ConfigAExtEn),
       RVB: bit'(CVA6ConfigBExtEn),
-      ZKN: bit'(0),
+      ZKN: bit'(1),
       RVV: bit'(CVA6ConfigVExtEn),
       RVC: bit'(CVA6ConfigCExtEn),
       RVH: bit'(CVA6ConfigHExtEn),

--- a/core/include/cv64a6_imafdczcheri_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdczcheri_sv39_config_pkg.sv
@@ -100,7 +100,7 @@ package cva6_config_pkg;
       XF8: bit'(CVA6ConfigF8En),
       RVA: bit'(CVA6ConfigAExtEn),
       RVB: bit'(CVA6ConfigBExtEn),
-      ZKN: bit'(0),
+      ZKN: bit'(1),
       RVV: bit'(CVA6ConfigVExtEn),
       RVC: bit'(CVA6ConfigCExtEn),
       RVH: bit'(CVA6ConfigHExtEn),

--- a/core/include/cv64a6_imafdczcheri_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdczcheri_sv39_config_pkg.sv
@@ -76,7 +76,7 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigMmuPresent = 1;
 
-  localparam CVA6ConfigRvfiTrace = 0;
+  localparam CVA6ConfigRvfiTrace = 1;
 
   localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       XLEN: unsigned'(CVA6ConfigXlen),

--- a/core/include/cv64a6_imafdczcheri_sv39_hpdcache_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdczcheri_sv39_hpdcache_wb_config_pkg.sv
@@ -100,7 +100,7 @@ package cva6_config_pkg;
       XF8: bit'(CVA6ConfigF8En),
       RVA: bit'(CVA6ConfigAExtEn),
       RVB: bit'(CVA6ConfigBExtEn),
-      ZKN: bit'(0),
+      ZKN: bit'(1),
       RVV: bit'(CVA6ConfigVExtEn),
       RVC: bit'(CVA6ConfigCExtEn),
       RVH: bit'(CVA6ConfigHExtEn),

--- a/core/include/cv64a6_imafdczcheri_sv39_hpdcache_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdczcheri_sv39_hpdcache_wb_config_pkg.sv
@@ -76,7 +76,7 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigMmuPresent = 1;
 
-  localparam CVA6ConfigRvfiTrace = 0;
+  localparam CVA6ConfigRvfiTrace = 1;
 
   localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       XLEN: unsigned'(CVA6ConfigXlen),

--- a/core/include/cv64a6_imafdczcheri_sv39_hpdcache_wb_rvfi_dii_config_pkg.sv
+++ b/core/include/cv64a6_imafdczcheri_sv39_hpdcache_wb_rvfi_dii_config_pkg.sv
@@ -98,7 +98,7 @@ package cva6_config_pkg;
       XF8: bit'(CVA6ConfigF8En),
       RVA: bit'(CVA6ConfigAExtEn),
       RVB: bit'(CVA6ConfigBExtEn),
-      ZKN: bit'(0),
+      ZKN: bit'(1),
       RVV: bit'(CVA6ConfigVExtEn),
       RVC: bit'(CVA6ConfigCExtEn),
       RVH: bit'(CVA6ConfigHExtEn),

--- a/core/include/cv64a6_imafdczcheri_sv39_rvfi_dii_config_pkg.sv
+++ b/core/include/cv64a6_imafdczcheri_sv39_rvfi_dii_config_pkg.sv
@@ -98,7 +98,7 @@ package cva6_config_pkg;
       XF8: bit'(CVA6ConfigF8En),
       RVA: bit'(CVA6ConfigAExtEn),
       RVB: bit'(CVA6ConfigBExtEn),
-      ZKN: bit'(0),
+      ZKN: bit'(1),
       RVV: bit'(CVA6ConfigVExtEn),
       RVC: bit'(CVA6ConfigCExtEn),
       RVH: bit'(CVA6ConfigHExtEn),

--- a/core/issue_read_operands.sv
+++ b/core/issue_read_operands.sv
@@ -853,6 +853,12 @@ module issue_read_operands
       fu_data_n[i].rs2       = CVA6Cfg.CheriPresent ? issue_instr_i[i].rs2 : '0;
       fu_data_n[i].use_ddc   = CVA6Cfg.CheriPresent ? issue_instr_i[i].use_ddc : '0;
 
+      if (CVA6Cfg.ZKN) begin
+        fu_data_n[i].orig_instr_aes_bits = {orig_instr_i[i][31:30], orig_instr_i[i][23:20]};
+      end else begin
+        fu_data_n[i].orig_instr_aes_bits = '0;
+      end
+
       if (CVA6Cfg.RVH) begin
         tinst_n[i] = issue_instr_i[i].ex.tinst;
       end
@@ -1249,9 +1255,6 @@ module issue_read_operands
     end else begin
       fu_data_q <= fu_data_n;
       alu_bypass_q <= alu_bypass_n;
-      if (CVA6Cfg.ZKN) begin
-        orig_instr_aes_bits <= {orig_instr_i[0][31:30], orig_instr_i[0][23:20]};
-      end
       if (CVA6Cfg.RVH) begin
         tinst_q <= tinst_n;
       end

--- a/corev_apu/tb/rvfi_tracer.sv
+++ b/corev_apu/tb/rvfi_tracer.sv
@@ -173,9 +173,9 @@ module rvfi_tracer #(
           end
 
           if (dest_is_fp) begin
-            $fwrite(f, " f%d 0x%h", rvfi_i[i].rd_addr, rvfi_i[i].rd_wdata);
+            $fwrite(f, " f%d 0x%h", rvfi_i[i].rd_addr, rvfi_i[i].rd_wdata[CVA6Cfg.XLEN-1:0]);
           end else if (rvfi_i[i].rd_addr != 0) begin
-            $fwrite(f, " x%d 0x%h", rvfi_i[i].rd_addr, rvfi_i[i].rd_wdata);
+            $fwrite(f, " x%d 0x%h", rvfi_i[i].rd_addr, rvfi_i[i].rd_wdata[CVA6Cfg.XLEN-1:0]);
             if (rvfi_i[i].mem_rmask != 0) begin
               $fwrite(f, " mem 0x%h", rvfi_i[i].mem_addr);
             end

--- a/verif/sim/cva6.py
+++ b/verif/sim/cva6.py
@@ -892,7 +892,7 @@ def load_config(args, cwd):
     elif base in ("cv64a6_imafdc_sv39_wb",):
       args.mabi = "lp64d"
       args.isa  = "rv64gc_zba_zbb_zbs_zbc"
-    elif base in ("cv64a6_imafdc_sv39", "cv64a6_imafdczcheri_sv39_hpdcache_wb", "cv64a6_imafdc_sv39_hpdcache", "cv64a6_imafdc_sv39_hpdcache_wb"):
+    elif base in ("cv64a6_imafdc_sv39", "cv64a6_imafdczcheri_sv39", "cv64a6_imafdczcheri_sv39_hpdcache_wb", "cv64a6_imafdc_sv39_hpdcache", "cv64a6_imafdc_sv39_hpdcache_wb"):
       args.mabi = "lp64d"
       args.isa  = "rv64gc_zba_zbb_zbs_zbc_zbkb_zbkx_zkne_zknd_zknh"
     elif base == "cv32a60x":

--- a/verif/sim/cva6.py
+++ b/verif/sim/cva6.py
@@ -665,7 +665,7 @@ def save_regr_report(report):
     failed_details = run_cmd(r"sed -e 's,.*_sim/,,' %s | grep '\(csv\|matched\)' | uniq | sed -e 'N;s/\\n/ /g' | grep '\[FAILED\]'" % report).strip()
     logging.info(failed_details)
     run_cmd(("echo %s >> %s" % (failed_details, report)))
-    #sys.exit(RET_FAIL) #Do not return error code in case of test fail.
+    sys.exit(RET_FAIL)
   logging.info("ISS regression report is saved to %s" % report)
 
 


### PR DESCRIPTION
This fixes various aspects of CI (including for our current configs, which were spuriously passing).

Since Spike enables ZKN, I've also enabled it and fixed it with CHERI, plus fixed an upstream bug.