### PR TITLE
Add explicit casts when printing pointers

### DIFF
--- a/corev_apu/fpga/src/bootrom/src/bouncebuf.c
+++ b/corev_apu/fpga/src/bootrom/src/bouncebuf.c
@@ -42,7 +42,7 @@ static int addr_aligned(struct bounce_buffer *state)
 	/* Check if start is aligned */
 	if ((unsigned long)state->user_buffer & align_mask) {
 		print_uart("Unaligned buffer address ");
-		print_uart_int(state->user_buffer);
+		print_uart_int((uint32_t) state->user_buffer);
 		print_uart("align mask");
 		print_uart_int(align_mask);
 		print_uart("(unsigned long)state->user_buffer & align_mask");

--- a/corev_apu/fpga/src/bootrom/src/dw_mmc.c
+++ b/corev_apu/fpga/src/bootrom/src/dw_mmc.c
@@ -76,7 +76,7 @@ static void dwmci_set_idma_desc(struct dwmci_idmac *idmac,
 	desc->addr = desc2;
 	desc->next_addr = (unsigned long)desc + sizeof(struct dwmci_idmac);
 	print_uart("descriptor pointer address: ");
-	print_uart_int(desc);
+	print_uart_int((uint32_t) desc);
 	print_uart("set descriptor: flags ");
 	print_uart_int(desc->flags);
 	print_uart(" cnt ");


### PR DESCRIPTION
Without these, Jenkins seems to error out building the bootrom. Presumably, this is caused by differences in strictness of different toolchain versions
