### PR TITLE
Fix spurious PCC trap when instruction ends at end of address space

### DIFF
--- a/core/issue_read_operands.sv
+++ b/core/issue_read_operands.sv
@@ -511,6 +511,7 @@ module issue_read_operands
         automatic cva6_cheri_pkg::cap_tval2_t cheri_tval2;
         automatic logic pc_below_base;
         automatic logic pc_above_top;
+        cheri_tval2 = '0;
         cheri_tval2.fault_type = cva6_cheri_pkg::CAP_INSTR_FETCH_FAULT;
         next_pc_off = {{CVA6Cfg.VLEN - 3{1'b0}}, issue_instr_i[i].is_compressed ? 3'h2 : 3'h4};
         {next_pc_carry, next_pc_addr} = {1'b0, issue_instr_i[i].pc} + {1'b0, next_pc_off};

--- a/core/issue_read_operands.sv
+++ b/core/issue_read_operands.sv
@@ -509,10 +509,14 @@ module issue_read_operands
         automatic logic [CVA6Cfg.VLEN-1:0] next_pc_addr;
         automatic logic next_pc_carry;
         automatic cva6_cheri_pkg::cap_tval2_t cheri_tval2;
+        automatic logic pc_below_base;
+        automatic logic pc_above_top;
         cheri_tval2.fault_type = cva6_cheri_pkg::CAP_INSTR_FETCH_FAULT;
-        next_pc_off = ((issue_instr_i[i].is_compressed) ? {{CVA6Cfg.VLEN-2{1'b0}}, 2'h2} : {{CVA6Cfg.VLEN-3{1'b0}}, 3'h4});
+        next_pc_off = {{CVA6Cfg.VLEN - 3{1'b0}}, issue_instr_i[i].is_compressed ? 3'h2 : 3'h4};
         {next_pc_carry, next_pc_addr} = {1'b0, issue_instr_i[i].pc} + {1'b0, next_pc_off};
-        if((cva6_cheri_pkg::addrw_t'(signed'(issue_instr_i[i].pc)) < pcc_base) || ({1'b0,cva6_cheri_pkg::addrw_t'(signed'(next_pc_addr))} > pcc_top) || (next_pc_carry && !pcc_bounds_root)) begin
+        pc_below_base = cva6_cheri_pkg::addrw_t'(signed'(issue_instr_i[i].pc)) < pcc_base;
+        pc_above_top = {next_pc_carry, cva6_cheri_pkg::addrw_t'(signed'(next_pc_addr))} > pcc_top;
+        if (!pcc_bounds_root && (pc_below_base || pc_above_top)) begin
           issue_pcc_ex_o[i].cause = cva6_cheri_pkg::CAP_EXCEPTION;
           cheri_tval2.fault_cause = cva6_cheri_pkg::CAP_BOUNDS_VIOLATION;
           issue_pcc_ex_o[i].tval2 = cheri_tval2;


### PR DESCRIPTION
This fixes an issue found by Louis-Emile Ploix and the Oxford team.

- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.

Fixes https://github.com/Capabilities-Limited/cheri-cva6/issues/104