### PR TITLE
Increase SD card SPI speed from clk/4 to clk/2 - more reliable under …

### DIFF
--- a/corev_apu/fpga/xilinx/xlnx_axi_quad_spi/tcl/run.tcl
+++ b/corev_apu/fpga/xilinx/xlnx_axi_quad_spi/tcl/run.tcl
@@ -7,7 +7,7 @@ create_project $ipName . -part $partNumber
 set_property board_part $boardName [current_project]
 
 create_ip -name axi_quad_spi -vendor xilinx.com -library ip -module_name $ipName
-set_property -dict [list CONFIG.C_USE_STARTUP {0} CONFIG.C_SCK_RATIO {4} CONFIG.C_FIFO_DEPTH {256} CONFIG.C_TYPE_OF_AXI4_INTERFACE {1} CONFIG.C_S_AXI4_ID_WIDTH {0}] [get_ips $ipName]
+set_property -dict [list CONFIG.C_USE_STARTUP {0} CONFIG.C_SCK_RATIO {2} CONFIG.C_FIFO_DEPTH {256} CONFIG.C_TYPE_OF_AXI4_INTERFACE {1} CONFIG.C_S_AXI4_ID_WIDTH {0}] [get_ips $ipName]
 
 generate_target {instantiation_template} [get_files ./$ipName.srcs/sources_1/ip/$ipName/$ipName.xci]
 generate_target all [get_files  ./$ipName.srcs/sources_1/ip/$ipName/$ipName.xci]


### PR DESCRIPTION
…load

Tested on Genesys2 with Sandisk Ultra 16GB (red/grey)

- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.

Pulls in a fix from Theo Markettos that reportedly improves SD card reliability. May be relevant to https://github.com/Capabilities-Limited/cheri-cva6/issues/53
