### PR TITLE
Remove deprecated set_prefer_sba from OpenOCD script

### DIFF
--- a/corev_apu/fpga/ariane.cfg
+++ b/corev_apu/fpga/ariane.cfg
@@ -32,9 +32,6 @@ gdb report_register_access_error enable
 riscv set_reset_timeout_sec 120
 riscv set_command_timeout_sec 120
 
-# prefer to use sba for system bus access
-riscv set_prefer_sba off
-
 # Try enabling address translation (only works for newer versions)
 if { [catch {riscv set_enable_virtual on} ] } {
     echo "Warning: This version of OpenOCD does not support address translation. To debug on virtual addresses, please update to the latest version." }


### PR DESCRIPTION
This causes an error with newer openocd versions

- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.

Fixes https://github.com/Capabilities-Limited/cheri-cva6/issues/50
