### PR TITLE
Reconnect debug_req in simulated testbench

### DIFF
--- a/corev_apu/tb/ariane_testharness.sv
+++ b/corev_apu/tb/ariane_testharness.sv
@@ -793,7 +793,7 @@ module ariane_testharness import cva6_cheri_pkg::*; #(
 `ifdef SPIKE_TANDEM
     .debug_req_i          ( 1'b0                ),
 `else
-    .debug_req_i          ( 1'b0      ),
+    .debug_req_i          ( debug_req_core      ),
 `endif
     .noc_req_o            ( axi_ariane_req      ),
     .noc_resp_i           ( axi_ariane_resp     )


### PR DESCRIPTION
This was hardwired to 1'b0 for TestRIG, but TestRIG now sets debug_enable low which forces the debug_req low more tidily

<!-- Contents within these symbols are commented out and will not appear in the PR description -->

<!-- Thanks for your contribution! Before sending us a pull request, please make sure you have read CONTRIBUTING.md -->

- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.


<!-- Please indicate why this PR is needed for the project -->

<!-- Is this PR related to existing issues? If so, link to them below -->

<!-- Are there limitations with the current state of this contribution? -->

<!-- If the contribution is not ready to be merged yet, please make this PR a draft: https://docs.github.com/fr/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests -->

