### PR TITLE
Disable all CHERI checks in debug mode

### DIFF
--- a/core/branch_unit.sv
+++ b/core/branch_unit.sv
@@ -238,7 +238,7 @@ module branch_unit #(
           cheri_fault = 1'b1;
         end
       end
-      if (cheri_fault) begin
+      if (cheri_fault && !debug_mode_i) begin
         branch_exception_o.cause = cva6_cheri_pkg::CAP_EXCEPTION;
         branch_exception_o.tval  = '0;
         branch_exception_o.tval2 = CVA6Cfg.GPLEN'(cva6_cheri_pkg::embed_cap_tval2(cheri_tval2));

--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -2968,7 +2968,7 @@ module csr_regfile
       csr_exception_o.valid = 1'b1;
     end
 
-    if (cheri_access_violation) begin
+    if (cheri_access_violation && !debug_mode_q) begin
       cheri_tval2.fault_type = cva6_cheri_pkg::CAP_INSTR_FETCH_FAULT;
       cheri_tval2.fault_cause = cva6_cheri_pkg::CAP_PERM_VIOLATION;
       csr_exception_o.cause = cva6_cheri_pkg::CAP_EXCEPTION;


### PR DESCRIPTION
We do not yet fully implement the RVY SDExt spec, but in any case all capability exceptions should be disabled with debug_mode

<!-- Contents within these symbols are commented out and will not appear in the PR description -->

<!-- Thanks for your contribution! Before sending us a pull request, please make sure you have read CONTRIBUTING.md -->

- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.


<!-- Please indicate why this PR is needed for the project -->

<!-- Is this PR related to existing issues? If so, link to them below -->

<!-- Are there limitations with the current state of this contribution? -->

<!-- If the contribution is not ready to be merged yet, please make this PR a draft: https://docs.github.com/fr/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests -->

