### PR TITLE
Enable Zcb in RVFI-DII and cheri configs

### DIFF
--- a/core/include/cv64a6_imafdc_sv39_hpdcache_wb_rvfi_dii_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_wb_rvfi_dii_config_pkg.sv
@@ -19,7 +19,7 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigCvxifEn = 0;
   localparam CVA6ConfigCExtEn = 1;
-  localparam CVA6ConfigZcbExtEn = 0;
+  localparam CVA6ConfigZcbExtEn = 1;
   localparam CVA6ConfigZcmpExtEn = 0;
   localparam CVA6ConfigAExtEn = 1;
   localparam CVA6ConfigHExtEn = 0;

--- a/core/include/cv64a6_imafdc_sv39_rvfi_dii_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_rvfi_dii_config_pkg.sv
@@ -19,7 +19,7 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigCvxifEn = 0;
   localparam CVA6ConfigCExtEn = 1;
-  localparam CVA6ConfigZcbExtEn = 0;
+  localparam CVA6ConfigZcbExtEn = 1;
   localparam CVA6ConfigZcmpExtEn = 0;
   localparam CVA6ConfigAExtEn = 1;
   localparam CVA6ConfigHExtEn = 0;

--- a/core/include/cv64a6_imafdczcheri_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdczcheri_sv39_config_pkg.sv
@@ -21,7 +21,7 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigCvxifEn = 0;
   localparam CVA6ConfigCExtEn = 1;
-  localparam CVA6ConfigZcbExtEn = 0;
+  localparam CVA6ConfigZcbExtEn = 1;
   localparam CVA6ConfigZcmpExtEn = 0;
   localparam CVA6ConfigAExtEn = 1;
   localparam CVA6ConfigBExtEn = 1;

--- a/core/include/cv64a6_imafdczcheri_sv39_hpdcache_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdczcheri_sv39_hpdcache_wb_config_pkg.sv
@@ -21,7 +21,7 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigCvxifEn = 0;
   localparam CVA6ConfigCExtEn = 1;
-  localparam CVA6ConfigZcbExtEn = 0;
+  localparam CVA6ConfigZcbExtEn = 1;
   localparam CVA6ConfigZcmpExtEn = 0;
   localparam CVA6ConfigAExtEn = 1;
   localparam CVA6ConfigBExtEn = 1;

--- a/core/include/cv64a6_imafdczcheri_sv39_hpdcache_wb_rvfi_dii_config_pkg.sv
+++ b/core/include/cv64a6_imafdczcheri_sv39_hpdcache_wb_rvfi_dii_config_pkg.sv
@@ -19,7 +19,7 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigCvxifEn = 0;
   localparam CVA6ConfigCExtEn = 1;
-  localparam CVA6ConfigZcbExtEn = 0;
+  localparam CVA6ConfigZcbExtEn = 1;
   localparam CVA6ConfigZcmpExtEn = 0;
   localparam CVA6ConfigAExtEn = 1;
   localparam CVA6ConfigHExtEn = 0;

--- a/core/include/cv64a6_imafdczcheri_sv39_rvfi_dii_config_pkg.sv
+++ b/core/include/cv64a6_imafdczcheri_sv39_rvfi_dii_config_pkg.sv
@@ -19,7 +19,7 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigCvxifEn = 0;
   localparam CVA6ConfigCExtEn = 1;
-  localparam CVA6ConfigZcbExtEn = 0;
+  localparam CVA6ConfigZcbExtEn = 1;
   localparam CVA6ConfigZcmpExtEn = 0;
   localparam CVA6ConfigAExtEn = 1;
   localparam CVA6ConfigHExtEn = 0;


### PR DESCRIPTION
There was no interesting CHERI composition here. This just needed some tweaks to Sail config to enable the extensions.

Once this is merged, we'll need to bump submodule pointers in TestRIG.

<!-- Contents within these symbols are commented out and will not appear in the PR description -->

<!-- Thanks for your contribution! Before sending us a pull request, please make sure you have read CONTRIBUTING.md -->

- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.


<!-- Please indicate why this PR is needed for the project -->

<!-- Is this PR related to existing issues? If so, link to them below -->

<!-- Are there limitations with the current state of this contribution? -->

<!-- If the contribution is not ready to be merged yet, please make this PR a draft: https://docs.github.com/fr/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests -->

