### PR TITLE
Fix bug where epcc could go unrepresentable

### DIFF
--- a/core/commit_stage.sv
+++ b/core/commit_stage.sv
@@ -123,14 +123,15 @@ module commit_stage
   end
 
   always_comb begin : prepare_pc_o
-    // Recalculate the PCC with correct address. Representability check not required because this was in-bounds at issue.
-    automatic
-    cva6_cheri_pkg::cap_reg_t
-    pcc_o = cva6_cheri_pkg::set_cap_reg_addr(
-        pcc_i, commit_instr_i[0].pc
-    );
+    // Recalculate the PCC with correct address.
+    // Representability check _is_ required because this will be used in exception cases
+    // TODO note that this metadata calculation is currently duplicated with the issue stage
+    automatic cva6_cheri_pkg::cap_meta_data_t pcc_meta;
+    automatic cva6_cheri_pkg::cap_reg_t pcc_o;
+    pcc_meta = cva6_cheri_pkg::get_cap_reg_meta_data(pcc_i);
+    pcc_o = cva6_cheri_pkg::set_cap_reg_address(pcc_i, commit_instr_i[0].pc, pcc_meta);
     pcc_o = cva6_cheri_pkg::set_cap_reg_flags(pcc_o, commit_instr_i[0].int_mode);
-    pc_o  = pcc_o;
+    pc_o = pcc_o;
   end
   if (CVA6Cfg.RVFI_DII) assign dii_id_o = commit_instr_i[0].dii_id;
   // Dirty the FP state if we are committing anything related to the FPU


### PR DESCRIPTION
This is a bug reported by Maxwell Pettet of the Oxford University Verification lab.
An unsafe address change was performed based on the assumption that if the PCC calculated from the commit stage is used as the PCC then the issue check must have succeeded and so the new PC is in-bounds, and so in representable bounds.
However, this calculated PCC is also used to determine EPCC in exception cases, including where the issue PCC was out of bounds. This could allow machine/supervisor mode to change bounds of a capability by carefully setting it up as a faulting PCC with an out-of-bounds address and then reading the produced EPCC.

Note that there may be opportunities to optimise this fix. As noted in the comment, the metadata being extracted is the same as is already extracted in the issue_stage.

<!-- Contents within these symbols are commented out and will not appear in the PR description -->

<!-- Thanks for your contribution! Before sending us a pull request, please make sure you have read CONTRIBUTING.md -->

- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.


<!-- Please indicate why this PR is needed for the project -->

<!-- Is this PR related to existing issues? If so, link to them below -->

<!-- Are there limitations with the current state of this contribution? -->

<!-- If the contribution is not ready to be merged yet, please make this PR a draft: https://docs.github.com/fr/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests -->

