### PR TITLE
Fix memory map clash between debug and tag control config

### DIFF
--- a/corev_apu/fpga/src/ariane_xilinx.sv
+++ b/corev_apu/fpga/src/ariane_xilinx.sv
@@ -346,7 +346,7 @@ assign rst = ddr_sync_reset;
 axi_pkg::xbar_rule_64_t [ariane_soc::NB_PERIPHERALS-1:0] addr_map;
 
 assign addr_map = '{
-  '{ idx: ariane_soc::TagCfg,   start_addr: ariane_soc::TagCfg,       end_addr: ariane_soc::TagCfg + ariane_soc::TagCfgLength         },
+  '{ idx: ariane_soc::TagCfg,   start_addr: ariane_soc::TagCfgBase,   end_addr: ariane_soc::TagCfgBase + ariane_soc::TagCfgLength     },
   '{ idx: ariane_soc::Debug,    start_addr: ariane_soc::DebugBase,    end_addr: ariane_soc::DebugBase + ariane_soc::DebugLength       },
   '{ idx: ariane_soc::ROM,      start_addr: ariane_soc::ROMBase,      end_addr: ariane_soc::ROMBase + ariane_soc::ROMLength           },
   '{ idx: ariane_soc::CLINT,    start_addr: ariane_soc::CLINTBase,    end_addr: ariane_soc::CLINTBase + ariane_soc::CLINTLength       },


### PR DESCRIPTION
Because of use of the index rather than the base address, accesses to the debug module would be routed to the tag controller config interface instead

<!-- Contents within these symbols are commented out and will not appear in the PR description -->

<!-- Thanks for your contribution! Before sending us a pull request, please make sure you have read CONTRIBUTING.md -->

- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.


<!-- Please indicate why this PR is needed for the project -->

<!-- Is this PR related to existing issues? If so, link to them below -->

<!-- Are there limitations with the current state of this contribution? -->

<!-- If the contribution is not ready to be merged yet, please make this PR a draft: https://docs.github.com/fr/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests -->

