### PR TITLE
Fix ASR priority issues

### DIFF
--- a/core/issue_read_operands.sv
+++ b/core/issue_read_operands.sv
@@ -523,13 +523,15 @@ module issue_read_operands
         pc_below_base = cva6_cheri_pkg::addrw_t'(signed'(issue_instr_i[i].pc)) < pcc_base;
         pc_above_top = {next_pc_carry, cva6_cheri_pkg::addrw_t'(signed'(next_pc_addr))} > pcc_top;
         cheri_fault = 1'b0;
+        // Special-case for ASR: unlike the other checks, this should happen after the instruction is
+        // fetched and decoded architecturally, and so only if it is not illegal for some other reason.
+        if (issue_instr_i[i].needs_asr && !issue_instr_i[i].ex.valid && !pcc[i].hperms.access_sys_regs) begin
+          cheri_fault = 1'b1;
+          cheri_tval2.fault_cause = cva6_cheri_pkg::CAP_PERM_VIOLATION;
+        end
         if (!pcc_bounds_root && (pc_below_base || pc_above_top)) begin
           cheri_fault = 1'b1;
           cheri_tval2.fault_cause = cva6_cheri_pkg::CAP_BOUNDS_VIOLATION;
-        end
-        if (issue_instr_i[i].needs_asr && !pcc[i].hperms.access_sys_regs) begin
-          cheri_fault = 1'b1;
-          cheri_tval2.fault_cause = cva6_cheri_pkg::CAP_PERM_VIOLATION;
         end
         if (!pcc[i].hperms.permit_execute) begin
           cheri_fault = 1'b1;


### PR DESCRIPTION
As found by Louis-Emile Ploix from the Oxford verification team, ASR checks are supposed to happen after the instruction is fetched and decoded, unlike the other PCC fetch checks.
Take Louis-Emile's suggested fix.

<!-- Contents within these symbols are commented out and will not appear in the PR description -->

<!-- Thanks for your contribution! Before sending us a pull request, please make sure you have read CONTRIBUTING.md -->

- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.

Fixes: https://github.com/Capabilities-Limited/cheri-cva6/issues/146

